### PR TITLE
Add token budget management for tool execution

### DIFF
--- a/budget.yaml
+++ b/budget.yaml
@@ -1,0 +1,7 @@
+global: 100000
+tools:
+  web_fetch: 50000
+  pdf_text: 25000
+tags:
+  high_priority: 80000
+  low_priority: 20000

--- a/core/agentControl.py
+++ b/core/agentControl.py
@@ -4,8 +4,10 @@ from core.tools.registry import discover, get
 from core.trace_context import set_trace
 from core.observability.trace import start_trace, log_event
 from core.observability.metrics import tool_calls_total, tool_latency_ms
+from core.budget import get_budget_manager, BudgetExceeded
 import time
 discover("plugins")
+budget_manager = get_budget_manager()
 class Step(BaseModel):
     tool: str
     args: Dict[str, Any]
@@ -13,17 +15,40 @@ def execute_steps(prompt: str, steps: List[Dict[str, Any]], thread_id=None, tags
     trace_id = start_trace(thread_id)
     set_trace(thread_id, trace_id, tags or [])
     out = []
-    for st in steps:
+    queued: List[Dict[str, Any]] = []
+    for idx, st in enumerate(steps):
         s = Step(**st)
         log_event(trace_id, "decision", "planner:step", {"tool": s.tool, "args": s.args, "tags": tags or []})
         spec = get(s.tool)
         t0 = time.time()
         try:
             res = spec.run(s.args)
+            tokens = res.get("tokens", 0)
+            try:
+                budget_manager.check_and_decrement(s.tool, tokens, tags or [])
+            except BudgetExceeded as be:
+                log_event(
+                    trace_id,
+                    "decision",
+                    "budget:exceeded",
+                    {
+                        "tool": s.tool,
+                        "scope": be.scope,
+                        "limit": be.limit,
+                        "used": be.used,
+                        "amount": be.amount,
+                        "tags": tags or [],
+                    },
+                )
+                tool_calls_total.labels(s.tool, "false").inc()
+                queued = steps[idx + 1 :]
+                out.append({"tool": s.tool, "error": "budget_exceeded", "details": str(be)})
+                break
+
             tool_calls_total.labels(s.tool, "true").inc()
-            tool_latency_ms.labels(s.tool).observe((time.time()-t0)*1000.0)
+            tool_latency_ms.labels(s.tool).observe((time.time() - t0) * 1000.0)
             out.append({"tool": s.tool, "output": res})
-        except Exception as e:
+        except Exception:
             tool_calls_total.labels(s.tool, "false").inc()
             raise
-    return {"trace_id": trace_id, "outputs": out}
+    return {"trace_id": trace_id, "outputs": out, "queued": queued}

--- a/core/budget.py
+++ b/core/budget.py
@@ -1,0 +1,113 @@
+import os
+from typing import Dict, Optional, Any, List
+import yaml
+
+class BudgetExceeded(Exception):
+    """Raised when a global or per-tool budget is exceeded."""
+
+    def __init__(self, scope: str, limit: int, used: int, amount: int):
+        self.scope = scope
+        self.limit = limit
+        self.used = used
+        self.amount = amount
+        super().__init__(f"{scope} budget exceeded: {used + amount}/{limit}")
+
+
+class BudgetManager:
+    """Manage token budgets across tools and globally.
+
+    Budgets can be supplied via a YAML file or environment variables.
+    Environment variables take precedence over YAML values.
+    
+    YAML format::
+        global: 1000
+        tools:
+          web_fetch: 500
+          pdf_text: 200
+    
+    Environment variables::
+        BUDGET_GLOBAL=1000
+        BUDGET_TOOL_WEB_FETCH=500
+    """
+
+    def __init__(self, config_path: Optional[str] = None):
+        self.global_limit: Optional[int] = None
+        self.tool_limits: Dict[str, int] = {}
+        self.global_used = 0
+        self.tool_used: Dict[str, int] = {}
+        self.tag_limits: Dict[str, int] = {}
+        self.tag_used: Dict[str, int] = {}
+
+        path = config_path or os.environ.get("BUDGET_CONFIG")
+        data: Dict[str, Any] = {}
+        if path and os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+
+        # load limits from YAML
+        if "global" in data:
+            self.global_limit = int(data["global"])
+        tools_section = data.get("tools", {})
+        for tool, limit in tools_section.items():
+            self.tool_limits[tool] = int(limit)
+        tags_section = data.get("tags", {})
+        for tag, limit in tags_section.items():
+            self.tag_limits[tag] = int(limit)
+
+        # environment overrides
+        env_global = os.environ.get("BUDGET_GLOBAL")
+        if env_global is not None:
+            self.global_limit = int(env_global)
+        for key, value in os.environ.items():
+            if key.startswith("BUDGET_TOOL_"):
+                tool = key[len("BUDGET_TOOL_"):].lower()
+                self.tool_limits[tool] = int(value)
+            if key.startswith("BUDGET_TAG_"):
+                tag = key[len("BUDGET_TAG_"):].lower()
+                self.tag_limits[tag] = int(value)
+
+    def remaining(self, tool: Optional[str] = None) -> Optional[int]:
+        if tool:
+            limit = self.tool_limits.get(tool)
+            used = self.tool_used.get(tool, 0)
+            if limit is None:
+                return None
+            return max(limit - used, 0)
+        if self.global_limit is None:
+            return None
+        return max(self.global_limit - self.global_used, 0)
+
+    def check_and_decrement(self, tool: str, amount: int, tags: Optional[List[str]] = None) -> None:
+        tags = tags or []
+        # Check global limit
+        if self.global_limit is not None and self.global_used + amount > self.global_limit:
+            raise BudgetExceeded("global", self.global_limit, self.global_used, amount)
+
+        # Check tool-specific limit
+        tool_limit = self.tool_limits.get(tool)
+        used_tool = self.tool_used.get(tool, 0)
+        if tool_limit is not None and used_tool + amount > tool_limit:
+            raise BudgetExceeded(tool, tool_limit, used_tool, amount)
+
+        # Check tag limits
+        for tag in tags:
+            limit = self.tag_limits.get(tag)
+            used = self.tag_used.get(tag, 0)
+            if limit is not None and used + amount > limit:
+                raise BudgetExceeded(tag, limit, used, amount)
+
+        # Decrement budgets
+        self.global_used += amount
+        self.tool_used[tool] = used_tool + amount
+        for tag in tags:
+            if tag in self.tag_limits:
+                self.tag_used[tag] = self.tag_used.get(tag, 0) + amount
+
+# Singleton helper
+_manager: Optional[BudgetManager] = None
+
+def get_budget_manager() -> BudgetManager:
+    global _manager
+    if _manager is None:
+        _manager = BudgetManager()
+    return _manager


### PR DESCRIPTION
## Summary
- add BudgetManager to track global, per-tool, and tag-based token limits
- check budgets in `execute_steps` and queue remaining steps when budgets are exceeded
- provide YAML configuration example for budgets

## Testing
- `pytest core`


------
https://chatgpt.com/codex/tasks/task_e_689b2d7aa56c832589765eeaf16348ea