### PR TITLE
feat: record tool registry requests

### DIFF
--- a/core/observability/metrics.py
+++ b/core/observability/metrics.py
@@ -1,3 +1,11 @@
 from prometheus_client import Counter, Histogram
+
 tool_calls_total = Counter("tool_calls_total", "Tool calls", ["tool","ok"])
 tool_latency_ms = Histogram("tool_latency_ms", "Tool latency (ms)", ["tool"])
+tool_requests_total = Counter(
+    "tool_requests_total", "Tool registry requests", ["tool", "status"]
+)
+
+
+def record_tool_request(tool: str, status: str) -> None:
+    tool_requests_total.labels(tool, status).inc()

--- a/core/tools/registry.py
+++ b/core/tools/registry.py
@@ -1,6 +1,7 @@
 import importlib, pkgutil, inspect
 from typing import Dict, Any, Callable, Type
 from pydantic import BaseModel
+from core.observability.metrics import record_tool_request
 class ToolSpec(BaseModel):
     name: str
     input_model: Type[BaseModel]
@@ -9,7 +10,10 @@ _REGISTRY: Dict[str, ToolSpec] = {}
 def register(tool: ToolSpec) -> None:
     _REGISTRY[tool.name] = tool
 def get(name: str) -> ToolSpec:
-    if name not in _REGISTRY: raise KeyError(f"tool not found: {name}")
+    if name not in _REGISTRY:
+        record_tool_request(name, "missing")
+        raise KeyError(f"tool not found: {name}")
+    record_tool_request(name, "found")
     return _REGISTRY[name]
 def discover(package: str = "plugins") -> None:
     pkg = importlib.import_module(package)


### PR DESCRIPTION
## Summary
- track tool registry lookups with new `tool_requests_total` metric
- log requests in `registry.get` for found and missing tools

## Testing
- `pytest core`


------
https://chatgpt.com/codex/tasks/task_e_689b43efe2048325aa894db23b943a75