### PR TITLE
Add tests for tool request metrics

### DIFF
--- a/core/observability/metrics.py
+++ b/core/observability/metrics.py
@@ -1,3 +1,27 @@
 from prometheus_client import Counter, Histogram
-tool_calls_total = Counter("tool_calls_total", "Tool calls", ["tool","ok"])
+from core.tools import registry
+
+tool_calls_total = Counter("tool_calls_total", "Tool calls", ["tool", "ok"])
 tool_latency_ms = Histogram("tool_latency_ms", "Tool latency (ms)", ["tool"])
+
+tool_requests_total = Counter(
+    "tool_requests_total", "Tool requests", ["tool", "found"]
+)
+
+
+def record_tool_request(tool_name: str) -> None:
+    """Record that a tool was requested.
+
+    Increments the ``tool_requests_total`` counter with ``found`` set to
+    ``"true"`` when the tool exists in the registry or ``"false"`` when the
+    registry lookup raises ``KeyError``. The ``KeyError`` is re-raised so the
+    caller can handle the missing tool case.
+    """
+
+    try:
+        registry.get(tool_name)
+    except KeyError:
+        tool_requests_total.labels(tool=tool_name, found="false").inc()
+        raise
+    else:
+        tool_requests_total.labels(tool=tool_name, found="true").inc()

--- a/core/tests/test_metrics.py
+++ b/core/tests/test_metrics.py
@@ -1,0 +1,46 @@
+import pytest
+from prometheus_client import Counter, CollectorRegistry
+
+from core.observability import metrics
+
+
+def _fresh_counter(monkeypatch):
+    registry = CollectorRegistry()
+    counter = Counter(
+        "tool_requests_total", "Tool requests", ["tool", "found"], registry=registry
+    )
+    monkeypatch.setattr(metrics, "tool_requests_total", counter)
+    return registry
+
+
+def test_record_tool_request_found(monkeypatch):
+    registry = _fresh_counter(monkeypatch)
+    monkeypatch.setattr(metrics.registry, "get", lambda name: object())
+
+    metrics.record_tool_request("echo")
+
+    assert (
+        registry.get_sample_value(
+            "tool_requests_total", {"tool": "echo", "found": "true"}
+        )
+        == 1.0
+    )
+
+
+def test_record_tool_request_missing(monkeypatch):
+    registry = _fresh_counter(monkeypatch)
+
+    def fake_get(_name):
+        raise KeyError("missing")
+
+    monkeypatch.setattr(metrics.registry, "get", fake_get)
+
+    with pytest.raises(KeyError):
+        metrics.record_tool_request("ghost")
+
+    assert (
+        registry.get_sample_value(
+            "tool_requests_total", {"tool": "ghost", "found": "false"}
+        )
+        == 1.0
+    )


### PR DESCRIPTION
## Summary
- track tool lookup results with a new `tool_requests_total` counter
- test `record_tool_request` for present and missing tools

## Testing
- `PYTHONPATH=. pytest core/tests/test_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b440f1e5083259eefac4defad2cc7