### PR TITLE
feat: add plugin manifest loader and scaffolder

### DIFF
--- a/core/plugins/__init__.py
+++ b/core/plugins/__init__.py
@@ -1,0 +1,3 @@
+"""Plugin discovery utilities."""
+from .loader import discover_plugins, PluginManifest
+__all__ = ["discover_plugins", "PluginManifest"]

--- a/core/plugins/loader.py
+++ b/core/plugins/loader.py
@@ -1,0 +1,70 @@
+import os
+import json
+import importlib.util
+import threading
+import inspect
+from typing import Dict, Any, List
+from pydantic import BaseModel, ValidationError
+
+# Track loaded plugin manifests by path -> mtime
+_loaded: Dict[str, float] = {}
+_lock = threading.Lock()
+
+class PluginManifest(BaseModel):
+    """Schema for plugin.json files."""
+    name: str
+    version: str
+    entry: str
+    scopes: List[str] | None = None
+    commands: List[str] | None = None
+
+
+def _log_error(mod_name: str, error: Exception) -> None:
+    # Lazy import to avoid circular dependency at module import
+    from core.tools.registry import _log_discovery_error  # type: ignore
+    _log_discovery_error(mod_name, error)
+
+
+def _load_module(path: str):
+    spec = importlib.util.spec_from_file_location(os.path.splitext(os.path.basename(path))[0], path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _register_from_module(module) -> None:
+    from core.tools.registry import register, ToolSpec
+    for _, obj in inspect.getmembers(module):
+        if isinstance(obj, ToolSpec):
+            register(obj)
+
+
+def discover_plugins(root: str = "plugins") -> None:
+    """Recursively discover plugin.json manifests under ``root`` and load entry modules."""
+    if not os.path.isdir(root):
+        return
+    with _lock:
+        for dirpath, _, filenames in os.walk(root):
+            if "plugin.json" not in filenames:
+                continue
+            manifest_path = os.path.join(dirpath, "plugin.json")
+            try:
+                mtime = os.path.getmtime(manifest_path)
+            except OSError:
+                continue
+            if _loaded.get(manifest_path) == mtime:
+                # unchanged
+                continue
+            try:
+                with open(manifest_path, "r", encoding="utf-8") as f:
+                    data: Dict[str, Any] = json.load(f)
+                manifest = PluginManifest(**data)
+                entry_path = os.path.join(dirpath, manifest.entry)
+                module = _load_module(entry_path)
+                _register_from_module(module)
+                _loaded[manifest_path] = mtime
+            except (IOError, ValidationError, Exception) as e:
+                _log_error(manifest_path, e)
+                continue

--- a/core/tests/test_plugin_manifest.py
+++ b/core/tests/test_plugin_manifest.py
@@ -1,0 +1,29 @@
+import json
+from core.plugins import discover_plugins
+from core.tools.registry import _REGISTRY
+
+
+def test_manifest_plugin_discovery(tmp_path):
+    plug = tmp_path / "a" / "b"
+    plug.mkdir(parents=True)
+    (plug / "plugin.json").write_text(json.dumps({
+        "name": "tmpdemo",
+        "version": "0.0.1",
+        "entry": "main.py"
+    }))
+    (plug / "main.py").write_text(
+        "from core.tools.registry import ToolSpec\n"
+        "def run(args):\n    return {'ok': True}\n"
+        "spec = ToolSpec(name='tmp_tool', input_model=None, run=run)\n"
+    )
+    discover_plugins(str(tmp_path))
+    assert "tmp_tool" in _REGISTRY
+
+
+def test_bad_manifest(tmp_path):
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "plugin.json").write_text("{}")
+    discover_plugins(str(tmp_path))
+    # Should not raise and not register anything
+    assert all(name != "" for name in _REGISTRY)

--- a/core/tools/registry.py
+++ b/core/tools/registry.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, Callable, Type, List
 from pydantic import BaseModel
 from core.observability.metrics import record_tool_request
 from core.tools.manifest import ensure_tool_entry
+from core.plugins import discover_plugins as _discover_plugins
 
 class ToolSpec(BaseModel):
     name: str
@@ -153,6 +154,7 @@ def discover(package: str = "plugins") -> None:
         _discover_microtools_from_dirs()
         _discover_templates()
         _load_remote_tools_from_config()
+        _discover_plugins()
         global _last_load_ts
         _last_load_ts = time.time()
 
@@ -175,3 +177,4 @@ def reload_if_needed() -> None:
             _log_discovery_error(pkg, e); continue
     _discover_microtools_from_dirs()
     _discover_templates()
+    _discover_plugins()

--- a/plugins/sample_plugin/plugin.json
+++ b/plugins/sample_plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "sample_plugin",
+  "version": "0.1.0",
+  "entry": "sample.py",
+  "scopes": ["demo"],
+  "commands": []
+}

--- a/plugins/sample_plugin/sample.py
+++ b/plugins/sample_plugin/sample.py
@@ -1,0 +1,9 @@
+from core.tools.registry import ToolSpec
+from core.instrumentation import instrument_tool
+
+@instrument_tool("sample_echo")
+def _run(args):
+    text = args.get("text", "")
+    return {"echo": text}
+
+spec = ToolSpec(name="sample_echo", input_model=None, run=_run)

--- a/tools/agent_plugin_cli.py
+++ b/tools/agent_plugin_cli.py
@@ -1,0 +1,45 @@
+import argparse
+import json
+from pathlib import Path
+
+TEMPLATE = (
+    "from core.tools.registry import ToolSpec\n\n"
+    "def run(args):\n"
+    "    return {{}}\n\n"
+    "spec = ToolSpec(name=\"{name}\", input_model=None, run=run)\n"
+)
+
+
+def create_plugin(name: str) -> None:
+    root = Path("plugins") / name
+    root.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "name": name,
+        "version": "0.1.0",
+        "entry": f"{name}.py",
+        "scopes": [],
+        "commands": []
+    }
+    with open(root / "plugin.json", "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+    with open(root / f"{name}.py", "w", encoding="utf-8") as f:
+        f.write(TEMPLATE.format(name=name))
+    print(f"created plugin template at {root}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="agent")
+    sub = parser.add_subparsers(dest="cmd")
+    plugin = sub.add_parser("plugin")
+    plugin_sub = plugin.add_subparsers(dest="plugin_cmd")
+    create = plugin_sub.add_parser("create")
+    create.add_argument("name")
+    args = parser.parse_args()
+    if args.cmd == "plugin" and args.plugin_cmd == "create":
+        create_plugin(args.name)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add manifest-based plugin loader with schema validation and recursive discovery
- integrate plugin discovery into registry hot reload
- add CLI to scaffold plugin templates and a sample plugin manifest

## Testing
- `PYTHONPATH=. pytest core/tests/test_registry_policy_planning.py core/tests/test_plugin_manifest.py`
- `python tools/agent_plugin_cli.py plugin create demo_cli_test`


------
https://chatgpt.com/codex/tasks/task_e_689db8c4f1f48325a535bd8ae15d81f0