### PR TITLE
Refine microtool async handling and registry

### DIFF
--- a/core/memory/db.py
+++ b/core/memory/db.py
@@ -1,36 +1,37 @@
 import os, sqlite3, time
+
 DB_PATH = os.getenv("AGENT_DB", "data/agent_memory.sqlite")
 MEM_DDL = [
-"""CREATE TABLE IF NOT EXISTS memory_entities(
+    """CREATE TABLE IF NOT EXISTS memory_entities(
   id TEXT PRIMARY KEY, name TEXT NOT NULL, type TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP);""",
-"""CREATE TABLE IF NOT EXISTS memory_claims(
+    """CREATE TABLE IF NOT EXISTS memory_claims(
   id TEXT PRIMARY KEY, entity_id TEXT, predicate TEXT,
   value TEXT, value_type TEXT, source_content_id TEXT,
   chunk_id TEXT, span_start INTEGER, span_end INTEGER,
   trust REAL DEFAULT 0.5, tags TEXT DEFAULT '[]',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY(entity_id) REFERENCES memory_entities(id));""",
-"""CREATE TABLE IF NOT EXISTS memory_facts(
+    """CREATE TABLE IF NOT EXISTS memory_facts(
   id TEXT PRIMARY KEY, claim_id TEXT NOT NULL, status TEXT DEFAULT 'active',
   version INTEGER DEFAULT 1, notes TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY(claim_id) REFERENCES memory_claims(id));""",
-"""CREATE TABLE IF NOT EXISTS memory_threads(
+    """CREATE TABLE IF NOT EXISTS memory_threads(
   id TEXT PRIMARY KEY, title TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP);""",
-"""CREATE TABLE IF NOT EXISTS memory_pins(
+    """CREATE TABLE IF NOT EXISTS memory_pins(
   id TEXT PRIMARY KEY, owner_type TEXT, owner_id TEXT, note TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP);""",
-"""CREATE TABLE IF NOT EXISTS traces(
+    """CREATE TABLE IF NOT EXISTS traces(
   id TEXT PRIMARY KEY, thread_id TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP);""",
-"""CREATE TABLE IF NOT EXISTS trace_events(
+    """CREATE TABLE IF NOT EXISTS trace_events(
   id TEXT PRIMARY KEY, trace_id TEXT, phase TEXT, role TEXT, payload TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY(trace_id) REFERENCES traces(id));""",
-# new cache table
-"""CREATE TABLE IF NOT EXISTS tool_cache(
+    # new cache table
+    """CREATE TABLE IF NOT EXISTS tool_cache(
   cache_key TEXT PRIMARY KEY,
   tool TEXT NOT NULL,
   args_hash TEXT NOT NULL,
@@ -39,8 +40,8 @@ MEM_DDL = [
   ttl_s INTEGER DEFAULT 0,
   created_at INTEGER DEFAULT (strftime('%s','now'))
 );""",
-# session key-value store
-"""CREATE TABLE IF NOT EXISTS session_kv(
+    # session key-value store
+    """CREATE TABLE IF NOT EXISTS session_kv(
   id TEXT PRIMARY KEY,
   thread_id TEXT,
   key TEXT,
@@ -49,64 +50,73 @@ MEM_DDL = [
 );""",
 ]
 
+
 def get_conn():
-	conn = sqlite3.connect(DB_PATH)
-	conn.execute("PRAGMA journal_mode=WAL;")
-	return conn
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute("PRAGMA journal_mode=WAL;")
+    return conn
+
 
 def init():
-	with get_conn() as c:
-		for ddl in MEM_DDL:
-			c.execute(ddl)
+    with get_conn() as c:
+        for ddl in MEM_DDL:
+            c.execute(ddl)
+
 
 # Simple cache helpers
 
 def cache_get(tool: str, args_hash: str) -> str | None:
-	with get_conn() as c:
-		row = c.execute(
-			"SELECT value, ttl_s, created_at FROM tool_cache WHERE tool=? AND args_hash=?",
-			(tool, args_hash)
-		).fetchone()
-	if not row:
-		return None
-	value, ttl_s, created_at = row
-	if ttl_s and int(time.time()) - int(created_at) > int(ttl_s):
-		with get_conn() as c:
-			c.execute("DELETE FROM tool_cache WHERE tool=? AND args_hash=?", (tool, args_hash))
-		return None
-	return value
+    key = f"{tool}:{args_hash}"
+    with get_conn() as c:
+        row = c.execute(
+            "SELECT value, ttl_s, created_at FROM tool_cache WHERE cache_key=?",
+            (key,),
+        ).fetchone()
+    if not row:
+        return None
+    value, ttl_s, created_at = row
+    if ttl_s and int(time.time()) - int(created_at) > int(ttl_s):
+        with get_conn() as c:
+            c.execute("DELETE FROM tool_cache WHERE cache_key=?", (key,))
+        return None
+    return value
+
 
 def cache_put(tool: str, args_hash: str, value: str, ttl_s: int = 0, version: int = 1) -> None:
-	with get_conn() as c:
-		c.execute(
-			"INSERT OR REPLACE INTO tool_cache(cache_key, tool, args_hash, value, version, ttl_s, created_at) VALUES(?,?,?,?,?,?,strftime('%s','now'))",
-			(f"{tool}:{args_hash}", tool, args_hash, value, version, ttl_s)
-		)
+    key = f"{tool}:{args_hash}"
+    with get_conn() as c:
+        c.execute(
+            "INSERT OR REPLACE INTO tool_cache(cache_key, tool, args_hash, value, version, ttl_s, created_at) VALUES(?,?,?,?,?,?,strftime('%s','now'))",
+            (key, tool, args_hash, value, version, ttl_s),
+        )
+
 
 # Session KV helpers
 
 def kv_put(thread_id: str | None, key: str, value: str) -> None:
-	if not thread_id:
-		return
-	with get_conn() as c:
-		c.execute(
-			"INSERT OR REPLACE INTO session_kv(id, thread_id, key, value, created_at) VALUES(?,?,?,?,strftime('%s','now'))",
-			(f"{thread_id}:{key}", thread_id, key, value)
-		)
+    if not thread_id:
+        return
+    with get_conn() as c:
+        c.execute(
+            "INSERT OR REPLACE INTO session_kv(id, thread_id, key, value, created_at) VALUES(?,?,?,?,strftime('%s','now'))",
+            (f"{thread_id}:{key}", thread_id, key, value),
+        )
+
 
 def kv_get(thread_id: str | None, key: str) -> str | None:
-	if not thread_id:
-		return None
-	with get_conn() as c:
-		row = c.execute("SELECT value FROM session_kv WHERE thread_id=? AND key=?", (thread_id, key)).fetchone()
-	return row[0] if row else None
+    if not thread_id:
+        return None
+    with get_conn() as c:
+        row = c.execute("SELECT value FROM session_kv WHERE thread_id=? AND key=?", (thread_id, key)).fetchone()
+    return row[0] if row else None
+
 
 def kv_recent(thread_id: str | None, limit: int = 20) -> list[tuple[str, str, int]]:
-	if not thread_id:
-		return []
-	with get_conn() as c:
-		rows = c.execute(
-			"SELECT key, value, created_at FROM session_kv WHERE thread_id=? ORDER BY created_at DESC LIMIT ?",
-			(thread_id, limit)
-		).fetchall()
-	return [(r[0], r[1], int(r[2])) for r in rows]
+    if not thread_id:
+        return []
+    with get_conn() as c:
+        rows = c.execute(
+            "SELECT key, value, created_at FROM session_kv WHERE thread_id=? ORDER BY created_at DESC LIMIT ?",
+            (thread_id, limit),
+        ).fetchall()
+    return [(r[0], r[1], int(r[2])) for r in rows]

--- a/core/tests/test_cache.py
+++ b/core/tests/test_cache.py
@@ -1,0 +1,16 @@
+import time, json
+from core.memory.db import cache_put, cache_get, init
+
+
+def test_cache_query_performance(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENT_DB", str(tmp_path / "cache.sqlite"))
+    init()
+    for i in range(1000):
+        cache_put("t", str(i), json.dumps({"i": i}))
+    start = time.time()
+    for i in range(1000):
+        assert cache_get("t", str(i)) is not None
+    elapsed = time.time() - start
+    # query by primary key should be fast
+    assert elapsed < 1.0
+

--- a/core/tests/test_microtools.py
+++ b/core/tests/test_microtools.py
@@ -5,30 +5,43 @@ from core.agentControl import execute_steps
 
 
 def test_microtool_discovery(tmp_path, monkeypatch):
-	monkeypatch.setenv("MICROTOOL_DIRS", "tools")
-	discover("")
-	assert get("search")
-	assert get("compare")
-	assert get("optimize")
+    monkeypatch.setenv("MICROTOOL_DIRS", "tools")
+    discover("")
+    assert get("search")
+    assert get("compare")
+    assert get("optimize")
 
 
 def test_microtool_usage_tracking(monkeypatch):
-	monkeypatch.setenv("MICROTOOL_DIRS", "tools")
-	monkeypatch.setenv("TOOLS_MANIFEST_PATH", "data/tools_manifest.json")
-	# avoid HITL for single step
-	monkeypatch.setenv("HITL_DEFAULT", "false")
-	discover("")
-	out = execute_steps("compare stuff", steps=[{"tool": "compare", "args": {"a": 1, "b": 1}}])
-	mf = load_manifest()
-	assert "compare" in mf and mf["compare"]["uses"] >= 1
+    monkeypatch.setenv("MICROTOOL_DIRS", "tools")
+    monkeypatch.setenv("TOOLS_MANIFEST_PATH", "data/tools_manifest.json")
+    # avoid HITL for single step
+    monkeypatch.setenv("HITL_DEFAULT", "false")
+    discover("")
+    out = execute_steps("compare stuff", steps=[{"tool": "compare", "args": {"a": 1, "b": 1}}])
+    mf = load_manifest()
+    assert "compare" in mf and mf["compare"]["uses"] >= 1
 
 
 def test_microtool_composite(monkeypatch):
-	monkeypatch.setenv("MICROTOOL_DIRS", "tools")
-	monkeypatch.setenv("HITL_DEFAULT", "false")
-	discover("")
-	data = ["a", "b", "c"]
-	out = execute_steps("optimize", steps=[{"tool": "optimize", "args": {"data": data, "term": "b", "cmp": "b"}}])
-	res = out["outputs"][0]["output"]
-	assert res["search"]["count"] == 1
-	assert res["compare"]["equal"] is True
+    monkeypatch.setenv("MICROTOOL_DIRS", "tools")
+    monkeypatch.setenv("HITL_DEFAULT", "false")
+    discover("")
+    data = ["a", "b", "c"]
+    out = execute_steps("optimize", steps=[{"tool": "optimize", "args": {"data": data, "term": "b", "cmp": "b"}}])
+    res = out["outputs"][0]["output"]
+    assert res["search"]["count"] == 1
+    assert res["compare"]["equal"] is True
+
+
+def test_sync_async_chain(monkeypatch):
+    monkeypatch.setenv("MICROTOOL_DIRS", "tools")
+    monkeypatch.setenv("HITL_DEFAULT", "false")
+    discover("")
+    steps = [
+        {"tool": "search", "args": {"data": ["x"], "term": "x"}},
+        {"tool": "async_echo", "args": {"msg": "ok"}},
+    ]
+    out = execute_steps("combo", steps=steps)
+    assert out["outputs"][0]["output"]["count"] == 1
+    assert out["outputs"][1]["output"]["echo"] == "ok"

--- a/core/tests/test_registry_policy_planning.py
+++ b/core/tests/test_registry_policy_planning.py
@@ -7,66 +7,80 @@ from core.agentControl import execute_steps
 
 
 def test_registry_discovers_plugins():
-	# should discover at least built-in tools
-	discover("plugins")
-	assert "web_fetch" in _REGISTRY
-	assert "pdf_text" in _REGISTRY
+    # should discover at least built-in tools
+    discover("plugins")
+    assert "web_fetch" in _REGISTRY
+    assert "pdf_text" in _REGISTRY
 
 
 def test_policy_path_restrictions(tmp_path, monkeypatch):
-	monkeypatch.setenv("POLICY_ENGINE_ENABLED", "true")
-	monkeypatch.setenv("FS_SAFE_ROOTS", str(tmp_path))
-	# allowed
-	check_tool_allowed("mcp.fs.read", {"path": str(tmp_path / "a.txt")})
-	# not allowed
-	try:
-		check_tool_allowed("mcp.fs.read", {"path": "/etc/hosts"})
-		assert False
-	except PermissionError:
-		assert True
+    monkeypatch.setenv("POLICY_ENGINE_ENABLED", "true")
+    monkeypatch.setenv("FS_SAFE_ROOTS", str(tmp_path))
+    # allowed
+    check_tool_allowed("mcp.fs.read", {"path": str(tmp_path / "a.txt")})
+    # not allowed
+    try:
+        check_tool_allowed("mcp.fs.read", {"path": "/etc/hosts"})
+        assert False
+    except PermissionError:
+        assert True
 
 
 def test_planning_conditionals(monkeypatch):
-	monkeypatch.setenv("ADVANCED_PLANNING", "true")
-	importlib.reload(adv)
-	plan = [
-		{"if": True, "then": [{"tool": "web_fetch", "args": {"url": "https://example.com"}}]},
-		{"loop": {"times": 2}, "steps": [{"tool": "web_fetch", "args": {"url": "https://example.com"}}]},
-	]
-	expanded = adv.expand_plan(plan)
-	assert len(expanded) == 3
+    monkeypatch.setenv("ADVANCED_PLANNING", "true")
+    importlib.reload(adv)
+    plan = [
+        {"if": True, "then": [{"tool": "web_fetch", "args": {"url": "https://example.com"}}]},
+        {"loop": {"times": 2}, "steps": [{"tool": "web_fetch", "args": {"url": "https://example.com"}}]},
+    ]
+    expanded = adv.expand_plan(plan)
+    assert len(expanded) == 3
 
 
 def test_retries_and_e2e_smoke(monkeypatch):
-	# Disable interactive approvals
-	monkeypatch.setenv("HITL_DEFAULT", "false")
-	# Avoid real network: stub requests.get used by plugins.web_fetch
-	import plugins.web_fetch as wf
-	class _Resp:
-		def __init__(self, text="ok"): self.text = text
-		def raise_for_status(self): return None
-	if wf.requests is not None:
-		monkeypatch.setattr(wf.requests, "get", lambda url, timeout=15: _Resp("ok"))
-	else:
-		import urllib.request
-		monkeypatch.setattr(urllib.request, "urlopen", lambda url, timeout=15: SimpleNamespace(read=lambda: b"ok"))
-	out = execute_steps("fetch https://example.com")
-	assert "trace_id" in out
-	assert isinstance(out.get("outputs"), list)
+    # Disable interactive approvals
+    monkeypatch.setenv("HITL_DEFAULT", "false")
+    # Avoid real network: stub requests.get used by plugins.web_fetch
+    import plugins.web_fetch as wf
+    class _Resp:
+        def __init__(self, text="ok"): self.text = text
+        def raise_for_status(self): return None
+    if wf.requests is not None:
+        monkeypatch.setattr(wf.requests, "get", lambda url, timeout=15: _Resp("ok"))
+    else:
+        import urllib.request
+        monkeypatch.setattr(urllib.request, "urlopen", lambda url, timeout=15: SimpleNamespace(read=lambda: b"ok"))
+    out = execute_steps("fetch https://example.com")
+    assert "trace_id" in out
+    assert isinstance(out.get("outputs"), list)
 
 
 def test_retry_logic(monkeypatch):
-	from core.tools.registry import ToolSpec, register
-	calls = {"n": 0}
-	def flaky(args):
-		calls["n"] += 1
-		if calls["n"] < 2:
-			raise RuntimeError("fail_once")
-		return {"ok": True}
-	spec = ToolSpec(name="_flaky", input_model=None, run=flaky)
-	register(spec)
-	monkeypatch.setenv("HITL_DEFAULT", "false")
-	# Provide explicit steps with retries
-	out = execute_steps("irrelevant", steps=[{"tool": "_flaky", "args": {}, "retries": 2}])
-	assert out["outputs"][0]["tool"] == "_flaky"
-	assert out["outputs"][0]["output"]["ok"] is True
+    from core.tools.registry import ToolSpec, register
+    calls = {"n": 0}
+    def flaky(args):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise RuntimeError("fail_once")
+        return {"ok": True}
+    spec = ToolSpec(name="_flaky", input_model=None, run=flaky)
+    register(spec)
+    monkeypatch.setenv("HITL_DEFAULT", "false")
+    out = execute_steps("irrelevant", steps=[{"tool": "_flaky", "args": {}, "retries": 2}])
+    assert out["outputs"][0]["tool"] == "_flaky"
+    assert out["outputs"][0]["output"]["ok"] is True
+
+
+def test_duplicate_registration_warning():
+    from core.tools.registry import ToolSpec, register
+    import warnings
+    def fn(args):
+        return {}
+    spec1 = ToolSpec(name="_dup", input_model=None, run=fn)
+    spec2 = ToolSpec(name="_dup", input_model=None, run=fn)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        register(spec1)
+        register(spec2)
+        assert any("duplicate tool registration" in str(wi.message) for wi in w)
+

--- a/core/tools/mcp_adapter.py
+++ b/core/tools/mcp_adapter.py
@@ -1,6 +1,6 @@
 import os
 from typing import Dict, Any
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from core.tools.registry import ToolSpec, register
 from core.instrumentation import instrument_tool
 from core.trace_context import set_trace
@@ -81,10 +81,10 @@ register(ToolSpec(name="mcp.git.status", input_model=GitStatusInput, run=_mcp_gi
 # Add delegate and kb.search microtools for convenience
 
 class DelegateInput(BaseModel):
-	prompt: str
-	thread_id: str | None = None
-	tags: list[str] = []
-	override_steps: list[dict[str, Any]] | None = None
+        prompt: str
+        thread_id: str | None = None
+        tags: list[str] = Field(default_factory=list)
+        override_steps: list[dict[str, Any]] | None = None
 
 @instrument_tool("agent.delegate")
 def _delegate(args: Dict[str, Any]) -> Dict[str, Any]:

--- a/core/tools/microtool.py
+++ b/core/tools/microtool.py
@@ -1,38 +1,69 @@
-from typing import Any, Callable, Dict, List, Optional
-from pydantic import BaseModel, Field
-from core.tools.registry import ToolSpec, register
+from typing import Any, Callable, Dict, List, Optional, get_type_hints
+from pydantic import BaseModel, Field, create_model
+from core.tools.registry import ToolSpec
 from core.instrumentation import instrument_tool
 
 
 class MicrotoolSpec(BaseModel):
-	name: str
-	description: str = ""
-	tags: List[str] = Field(default_factory=list)
-	input_model: Optional[type[BaseModel]] = None
+    name: str
+    description: str = ""
+    tags: List[str] = Field(default_factory=list)
+    input_model: Optional[type[BaseModel]] = None
 
 
-def microtool(name: str, *, description: str = "", tags: List[str] | None = None, input_model: Optional[type[BaseModel]] = None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-	def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
-		mt_spec = MicrotoolSpec(name=name, description=description, tags=tags or [], input_model=input_model)
-		setattr(fn, "_microtool_spec", mt_spec)
-		# Defer manifest entry until discovery so file path is known
-		return fn
-	return decorator
+def microtool(
+    name: str,
+    *,
+    description: str = "",
+    tags: List[str] | None = None,
+    input_model: Optional[type[BaseModel]] = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        model = input_model
+        if model is None:
+            import inspect
+
+            hints = get_type_hints(fn)
+            sig = inspect.signature(fn)
+            fields: Dict[str, tuple[Any, Any]] = {}
+            for param_name, param in sig.parameters.items():
+                if param.kind in (
+                    inspect.Parameter.VAR_POSITIONAL,
+                    inspect.Parameter.VAR_KEYWORD,
+                ):
+                    continue
+                ann = hints.get(param_name, Any)
+                default = param.default if param.default is not inspect._empty else ...
+                fields[param_name] = (ann, default)
+            if fields:
+                model = create_model(f"{fn.__name__.title()}Input", **fields)  # type: ignore
+        mt_spec = MicrotoolSpec(name=name, description=description, tags=tags or [], input_model=model)
+        setattr(fn, "_microtool_spec", mt_spec)
+        # Defer manifest entry until discovery so file path is known
+        return fn
+
+    return decorator
 
 
 def build_toolspec_from_microtool(fn: Callable[..., Any]) -> ToolSpec:
-	import asyncio, inspect
-	mt: MicrotoolSpec = getattr(fn, "_microtool_spec")
-	is_async = inspect.iscoroutinefunction(fn)
-	@instrument_tool(mt.name)
-	def _run(args: Dict[str, Any]) -> Dict[str, Any]:
-		kwargs = args if isinstance(args, dict) else {}
-		if is_async:
-			# Execute coroutine in a fresh event loop within thread worker
-			res = asyncio.run(fn(**kwargs))
-		else:
-			res = fn(**kwargs)
-		if isinstance(res, dict):
-			return res
-		return {"result": res}
-	return ToolSpec(name=mt.name, input_model=mt.input_model, run=_run)
+    import inspect
+
+    mt: MicrotoolSpec = getattr(fn, "_microtool_spec")
+    model = mt.input_model
+    if inspect.iscoroutinefunction(fn):
+
+        @instrument_tool(mt.name)
+        async def _run(args: Dict[str, Any]) -> Dict[str, Any]:
+            kwargs = model(**(args or {})).model_dump() if model else (args or {})
+            res = await fn(**kwargs)
+            return res if isinstance(res, dict) else {"result": res}
+
+    else:
+
+        @instrument_tool(mt.name)
+        def _run(args: Dict[str, Any]) -> Dict[str, Any]:
+            kwargs = model(**(args or {})).model_dump() if model else (args or {})
+            res = fn(**kwargs)
+            return res if isinstance(res, dict) else {"result": res}
+
+    return ToolSpec(name=mt.name, input_model=model, run=_run)

--- a/core/tools/registry.py
+++ b/core/tools/registry.py
@@ -1,5 +1,5 @@
-import importlib, pkgutil, inspect, os, json, time, threading, sys
-from typing import Dict, Any, Callable, Type, List
+import importlib, pkgutil, inspect, os, json, time, threading, sys, warnings
+from typing import Dict, Any, Callable, Type, List, Awaitable
 from pydantic import BaseModel
 from core.observability.metrics import record_tool_request
 from core.tools.manifest import ensure_tool_entry
@@ -7,7 +7,7 @@ from core.tools.manifest import ensure_tool_entry
 class ToolSpec(BaseModel):
     name: str
     input_model: Type[BaseModel] | None = None
-    run: Callable[[Dict[str, Any]], Dict[str, Any]] | Callable[..., Any]
+    run: Callable[[Dict[str, Any]], Dict[str, Any] | Awaitable[Dict[str, Any]]]
 
 _REGISTRY: Dict[str, ToolSpec] = {}
 _DISCOVERED_PACKAGES: List[str] = []
@@ -19,6 +19,8 @@ _lock = threading.Lock()
 
 
 def register(tool: ToolSpec) -> None:
+    if tool.name in _REGISTRY:
+        warnings.warn(f"duplicate tool registration: {tool.name}")
     _REGISTRY[tool.name] = tool
 
 
@@ -45,15 +47,21 @@ def _load_remote_tools_from_config() -> None:
         return
     try:
         from core.tools.remote import RemoteToolConfig, build_remote_tool
+        from pydantic import ValidationError
         with open(_REMOTE_CONFIG_PATH, "r", encoding="utf-8") as f:
             cfg = json.load(f)
         tools = cfg if isinstance(cfg, list) else cfg.get("tools", [])
         for item in tools:
             try:
-                spec = build_remote_tool(RemoteToolConfig(**item))
-                register(spec)
-            except Exception:
+                cfg_item = RemoteToolConfig(**item)
+            except Exception as e:
+                _log_discovery_error("remote_tool_config_item", e)
                 continue
+            try:
+                spec = build_remote_tool(cfg_item)
+                register(spec)
+            except Exception as e:
+                _log_discovery_error(f"remote_tool:{getattr(cfg_item, 'name', 'unknown')}", e)
     except Exception as e:
         _log_discovery_error("remote_tools_config", e)
 

--- a/tools/async_echo.py
+++ b/tools/async_echo.py
@@ -1,0 +1,9 @@
+from core.tools.microtool import microtool
+import asyncio
+
+
+@microtool("async_echo", description="Asynchronously echo a message", tags=["async"])
+async def async_echo(msg: str, delay: float = 0.0) -> dict:
+    await asyncio.sleep(delay)
+    return {"echo": msg}
+

--- a/tools/compare.py
+++ b/tools/compare.py
@@ -1,5 +1,7 @@
+from typing import Any
 from core.tools.microtool import microtool
 
+
 @microtool("compare", description="Compare two values", tags=["compare"])
-def compare(a, b) -> dict:
-	return {"equal": a == b, "a": a, "b": b}
+def compare(a: Any, b: Any) -> dict:
+    return {"equal": a == b, "a": a, "b": b}

--- a/tools/optimize.py
+++ b/tools/optimize.py
@@ -1,10 +1,11 @@
 from core.tools.microtool import microtool
-from tools.search import search
-from tools.compare import compare
+from core.tools.registry import get
 
 @microtool("optimize", description="Simple composite: search then compare first match", tags=["composite"])
 def optimize(data: list[str], term: str, cmp: str) -> dict:
-	res = search(data=data, term=term)
-	first = res["matches"][0] if res["count"] else None
-	cmp_res = compare(first, cmp)
-	return {"search": res, "compare": cmp_res}
+    search_spec = get("search")
+    compare_spec = get("compare")
+    res = search_spec.run({"data": data, "term": term})
+    first = res["matches"][0] if res["count"] else None
+    cmp_res = compare_spec.run({"a": first, "b": cmp})
+    return {"search": res, "compare": cmp_res}

--- a/tools/search.py
+++ b/tools/search.py
@@ -1,9 +1,13 @@
 from core.tools.microtool import microtool
 
-@microtool("search", description="Search for a term in a list", tags=["search","list"])
-def search(data: list[str], term: str, case_sensitive: bool = False) -> dict:
-	if case_sensitive:
-		matches = [x for x in data if term in str(x)]
-	else:
-		matches = [x for x in data if term.lower() in str(x).lower()]
-	return {"matches": matches, "count": len(matches)}
+@microtool("search", description="Search for a term in a list", tags=["search", "list"])
+def search(data: list[str], term: str, *, case_sensitive: bool = False) -> dict:
+    """Search for ``term`` within ``data``.
+
+    ``case_sensitive`` is a keyword-only flag controlling case sensitivity.
+    """
+    if case_sensitive:
+        matches = [x for x in data if term in str(x)]
+    else:
+        matches = [x for x in data if term.lower() in str(x).lower()]
+    return {"matches": matches, "count": len(matches)}


### PR DESCRIPTION
## Summary
- auto-generate microtool input models from type hints and return awaitables for async tools
- warn on duplicate tool registrations and log malformed remote tool configs
- query cache via primary key and support async tools in agent control

## Testing
- `PYTHONPATH=$PWD pytest core/tests/test_microtools.py core/tests/test_registry_policy_planning.py core/tests/test_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689db8d100608325b2368f2a7ef8edc0