### PR TITLE
feat: add messaging and hybrid retrieval

### DIFF
--- a/core/planning/advanced.py
+++ b/core/planning/advanced.py
@@ -37,6 +37,11 @@ def expand_plan(raw_steps: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 n = int(spec.get("range", spec.get("times", 0)) or 0)
                 for _ in range(max(0, n)):
                     _expand(item.get("steps", []))
+            elif "retry" in item and isinstance(item.get("steps"), list):
+                spec = item.get("retry") or {}
+                n = int(spec.get("max", 1) or 1)
+                for _ in range(max(0, n)):
+                    _expand(item.get("steps", []))
             else:
                 expanded.append(item)
 

--- a/core/tests/test_multiagent_messaging.py
+++ b/core/tests/test_multiagent_messaging.py
@@ -1,0 +1,53 @@
+import importlib, os, tempfile
+
+
+def setup_module(module):
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    os.environ["AGENT_DB"] = path
+    import core.memory.db as db
+    importlib.reload(db)
+    db.init()
+    module.db = db
+    os.environ["ENABLE_SEMANTIC_SEARCH"] = "false"
+    import core.knowledge.search as ks
+    importlib.reload(ks)
+    module.ks = ks
+
+
+def teardown_module(module):
+    db_path = os.environ.get("AGENT_DB")
+    if db_path and os.path.exists(db_path):
+        os.remove(db_path)
+    if "AGENT_DB" in os.environ:
+        del os.environ["AGENT_DB"]
+    import importlib
+    import core.memory.db as db_module
+    importlib.reload(db_module)
+    db_module.init()
+
+
+def test_message_roundtrip():
+    import core.tools.mcp_adapter as mcp
+    importlib.reload(mcp)
+    mcp._agent_message({
+        "thread_id": "t1",
+        "sender": "alice",
+        "recipient": "bob",
+        "content": "hello bob",
+    })
+    inbox = mcp._agent_inbox({"thread_id": "t1", "recipient": "bob"})
+    assert any(m["content"] == "hello bob" for m in inbox["messages"])
+
+
+def test_keyword_and_hybrid_search():
+    with db.get_conn() as c:
+        c.execute("INSERT OR REPLACE INTO traces(id, thread_id) VALUES(?,?)", ("tr1", "t1"))
+        c.execute(
+            "INSERT INTO trace_events(id, trace_id, phase, role, payload) VALUES(?,?,?,?,?)",
+            ("ev1", "tr1", "phase", "role", "This is a hello message"),
+        )
+    res_kw = ks.keyword_query("hello")
+    assert any("hello" in r["text"].lower() for r in res_kw)
+    res_hyb = ks.hybrid_query("hello")
+    assert res_hyb


### PR DESCRIPTION
## Summary
- add persistent message storage with send/inbox tools
- expose math eval and DuckDuckGo search microtools
- support hybrid keyword+vector retrieval and plan retries

## Testing
- `PYTHONPATH=. pytest core/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689db8ede7888325999e1cd9cf452913