### PR TITLE
Add self-optimization logging, introspection, and local LLM support

### DIFF
--- a/core/llm/__init__.py
+++ b/core/llm/__init__.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import os
 from typing import Dict, Optional
 
-from .providers import BaseLLMProvider, LocalHFProvider, OpenAIProvider
+from .providers import BaseLLMProvider, LocalHFProvider, OpenAIProvider, GPT4AllProvider
 
 _PROVIDER: Optional[BaseLLMProvider] = None
 
@@ -42,6 +42,8 @@ def get_provider(config: Optional[Dict[str, str]] = None) -> BaseLLMProvider:
         _PROVIDER = OpenAIProvider(model=model)
     elif provider_name.lower() in {"local", "hf", "huggingface"}:
         _PROVIDER = LocalHFProvider(model_name=model)
+    elif provider_name.lower() in {"gpt4all", "gpt4a"}:
+        _PROVIDER = GPT4AllProvider(model_name=model)
     else:  # pragma: no cover - unexpected config
         raise ValueError(f"Unknown LLM provider: {provider_name}")
 
@@ -52,6 +54,7 @@ __all__ = [
     "BaseLLMProvider",
     "OpenAIProvider",
     "LocalHFProvider",
+    "GPT4AllProvider",
     "get_provider",
 ]
 

--- a/core/tests/test_agent_suggest.py
+++ b/core/tests/test_agent_suggest.py
@@ -1,0 +1,22 @@
+import types
+import sys
+
+from plugins import agent_suggest
+
+
+def test_agent_suggest_offline(monkeypatch):
+    class DummyGPT4All:
+        def __init__(self, *a, **kw):
+            pass
+
+        def generate(self, prompt, **kw):
+            return "ok"
+
+    monkeypatch.setenv("LLM_PROVIDER", "gpt4all")
+    import core.llm
+    core.llm._PROVIDER = None  # reset singleton
+    monkeypatch.setitem(sys.modules, "gpt4all", types.SimpleNamespace(GPT4All=DummyGPT4All))
+    out = agent_suggest.spec_refactor.run({"code": "print(1)"})
+    assert "ok" in out["suggestion"]
+    out2 = agent_suggest.spec_create.run({"prompt": "add numbers"})
+    assert "ok" in out2["suggestion"]

--- a/core/tests/test_gpu_quantization.py
+++ b/core/tests/test_gpu_quantization.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+def test_gpu_quantization_support():
+    try:
+        import torch
+    except Exception:
+        pytest.skip("torch not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    try:
+        import bitsandbytes as bnb
+    except Exception:
+        pytest.skip("bitsandbytes not installed")
+    assert hasattr(bnb.nn, "Linear4bit")
+    assert hasattr(bnb.nn, "Linear8bitLt")

--- a/core/tests/test_usage_introspection.py
+++ b/core/tests/test_usage_introspection.py
@@ -1,0 +1,32 @@
+import json
+import os
+from importlib import reload
+from tempfile import TemporaryDirectory
+
+
+def test_usage_and_introspection(monkeypatch):
+    with TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "usage.db")
+        manifest_path = os.path.join(tmpdir, "manifest.json")
+        monkeypatch.setenv("AGENT_USAGE_DB", db_path)
+        monkeypatch.setenv("TOOLS_MANIFEST_PATH", manifest_path)
+        import core.tools.manifest as manifest_module
+        reload(manifest_module)
+        from core import usage_db
+        reload(usage_db)
+        from core.usage_db import log_run
+        import plugins.introspect as introspect
+        reload(introspect)
+        manifest = {
+            "used": {"uses": 1, "errors": 0, "path": "", "tags": [], "composite_of": [], "description": "", "last_used": 0},
+            "unused": {"uses": 0, "errors": 0, "path": "", "tags": [], "composite_of": [], "description": "", "last_used": 0},
+        }
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f)
+        log_run("cmd1", 0, 100, None)
+        for _ in range(3):
+            log_run("cmd2", 1, 50, "fail")
+        out = introspect.spec.run({})
+        assert "unused" in out["unused_plugins"]
+        assert "cmd2" in out["failing_commands"]
+        assert "cmd2" in out["helper_suggestions"]

--- a/core/usage_db.py
+++ b/core/usage_db.py
@@ -1,0 +1,35 @@
+import os
+import sqlite3
+import time
+import threading
+from typing import Optional
+
+_DB_PATH = os.path.expanduser(os.getenv("AGENT_USAGE_DB", "~/.agent/usage.db"))
+_lock = threading.Lock()
+
+def _ensure_db() -> None:
+    os.makedirs(os.path.dirname(_DB_PATH), exist_ok=True)
+    with sqlite3.connect(_DB_PATH) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts INTEGER,
+                command TEXT,
+                exit_code INTEGER,
+                exec_ms INTEGER,
+                error TEXT
+            )
+            """
+        )
+        conn.commit()
+
+def log_run(command: str, exit_code: int, exec_ms: int, error: Optional[str] = None) -> None:
+    _ensure_db()
+    with _lock:
+        with sqlite3.connect(_DB_PATH) as conn:
+            conn.execute(
+                "INSERT INTO runs (ts, command, exit_code, exec_ms, error) VALUES (?,?,?,?,?)",
+                (int(time.time()), command, exit_code, exec_ms, error),
+            )
+            conn.commit()

--- a/plugins/agent_suggest.py
+++ b/plugins/agent_suggest.py
@@ -1,0 +1,27 @@
+from core.instrumentation import instrument_tool
+from core.llm import get_provider
+from core.tools.registry import ToolSpec
+
+
+def _provider():
+    return get_provider({"provider": "gpt4all"})
+
+
+@instrument_tool("agent_suggest_refactor")
+def _refactor(args):
+    code = args.get("code", "")
+    prompt = f"Refactor the following code:\n{code}"
+    suggestion = _provider().generate(prompt)
+    return {"suggestion": suggestion}
+
+
+@instrument_tool("agent_suggest_create")
+def _create(args):
+    text = args.get("prompt", "")
+    prompt = f"Create helper code for:\n{text}"
+    suggestion = _provider().generate(prompt)
+    return {"suggestion": suggestion}
+
+
+spec_refactor = ToolSpec(name="agent_suggest_refactor", input_model=None, run=_refactor)
+spec_create = ToolSpec(name="agent_suggest_create", input_model=None, run=_create)

--- a/plugins/introspect.py
+++ b/plugins/introspect.py
@@ -1,0 +1,28 @@
+import os
+import sqlite3
+from core.instrumentation import instrument_tool
+from core.tools.registry import ToolSpec
+from core.tools.manifest import load_manifest
+
+_DB_PATH = os.path.expanduser(os.getenv("AGENT_USAGE_DB", "~/.agent/usage.db"))
+
+@instrument_tool("introspect")
+def _run(args):
+    data = {"unused_plugins": [], "failing_commands": [], "helper_suggestions": []}
+    mf = load_manifest()
+    data["unused_plugins"] = [n for n, v in mf.items() if int(v.get("uses", 0)) == 0]
+    if os.path.exists(_DB_PATH):
+        conn = sqlite3.connect(_DB_PATH)
+        rows = conn.execute(
+            "SELECT command, exit_code, COUNT(*) FROM runs GROUP BY command, exit_code"
+        ).fetchall()
+        conn.close()
+        failing = [cmd for cmd, code, _ in rows if code != 0]
+        data["failing_commands"] = sorted(set(failing))
+        counts = {}
+        for cmd, _, cnt in rows:
+            counts[cmd] = counts.get(cmd, 0) + cnt
+        data["helper_suggestions"] = [cmd for cmd, cnt in counts.items() if cnt >= 3]
+    return data
+
+spec = ToolSpec(name="introspect", input_model=None, run=_run)


### PR DESCRIPTION
## Summary
- Track every tool execution in a SQLite usage database
- Add introspection plugin to surface unused plugins, failing commands, and helper suggestions
- Provide local GPT4All provider and agent suggestion tools for refactor/create prompts

## Testing
- `python3 -m pytest core/tests/test_usage_introspection.py core/tests/test_agent_suggest.py core/tests/test_gpu_quantization.py core/tests/test_microtools.py`


------
https://chatgpt.com/codex/tasks/task_e_689db8f6c09c8325a5d99c223e2f0d38