### PR TITLE
Handle removal of plugin manifests

### DIFF
--- a/core/tests/test_plugin_manifest.py
+++ b/core/tests/test_plugin_manifest.py
@@ -27,3 +27,25 @@ def test_bad_manifest(tmp_path):
     discover_plugins(str(tmp_path))
     # Should not raise and not register anything
     assert all(name != "" for name in _REGISTRY)
+
+
+def test_removed_plugin(tmp_path):
+    plug = tmp_path / "del" / "plug"
+    plug.mkdir(parents=True)
+    (plug / "plugin.json").write_text(json.dumps({
+        "name": "tmpdel",
+        "version": "0.0.1",
+        "entry": "main.py",
+    }))
+    (plug / "main.py").write_text(
+        "from core.tools.registry import ToolSpec\n"
+        "def run(args):\n    return {'ok': True}\n"
+        "spec = ToolSpec(name='tmp_tool_remove', input_model=None, run=run)\n"
+    )
+    discover_plugins(str(tmp_path))
+    assert "tmp_tool_remove" in _REGISTRY
+    # Remove the plugin directory and rediscover
+    import shutil
+    shutil.rmtree(plug)
+    discover_plugins(str(tmp_path))
+    assert "tmp_tool_remove" not in _REGISTRY


### PR DESCRIPTION
## Summary
- track tools registered by each plugin manifest
- purge tools when their manifest disappears
- add regression test verifying removed plugins are unregistered

## Testing
- `PYTHONPATH=. pytest core/tests/test_plugin_manifest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689dddd113f88325953b4696e90b9e99