### PR TITLE
Add Temporal worker tests and update CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,5 +8,6 @@ jobs:
       - uses: actions/setup-python@v5
         with: { python-version: '3.11' }
       - run: pip install ruff pytest
+      - run: pip install -r services/temporal-worker/requirements.txt
       - run: ruff --version
       - run: pytest -q || true

--- a/services/temporal-worker/tests/test_main.py
+++ b/services/temporal-worker/tests/test_main.py
@@ -1,0 +1,62 @@
+import sys
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+SERVICE_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(SERVICE_DIR))
+sys.path.append(str(REPO_ROOT))
+
+import main
+
+
+def test_main_runs(monkeypatch):
+    start_mock = MagicMock()
+    monkeypatch.setattr(main, "start_http_server", start_mock)
+
+    async def fake_connect(addr):
+        assert addr == "temporal:7233"
+        return "client"
+
+    monkeypatch.setattr(main.Client, "connect", fake_connect, raising=False)
+
+    run_mock = AsyncMock()
+
+    class DummyWorker:
+        def __init__(self, client, task_queue, workflows, activities):
+            assert client == "client"
+            assert task_queue == "agent-tq"
+            assert workflows == [main.AgentWorkflow]
+            assert activities == [main.run_steps]
+            self.run = run_mock
+
+    monkeypatch.setattr(main, "Worker", DummyWorker)
+
+    asyncio.run(main.main())
+
+    start_mock.assert_called_once_with(9109)
+    run_mock.assert_awaited_once()
+
+
+def test_main_worker_failure(monkeypatch):
+    start_mock = MagicMock()
+    monkeypatch.setattr(main, "start_http_server", start_mock)
+
+    async def fake_connect(addr):
+        return "client"
+
+    monkeypatch.setattr(main.Client, "connect", fake_connect, raising=False)
+
+    run_mock = AsyncMock(side_effect=RuntimeError("fail"))
+
+    class DummyWorker:
+        def __init__(self, client, task_queue, workflows, activities):
+            self.run = run_mock
+
+    monkeypatch.setattr(main, "Worker", DummyWorker)
+
+    with pytest.raises(RuntimeError, match="fail"):
+        asyncio.run(main.main())

--- a/services/temporal-worker/tests/test_workflow.py
+++ b/services/temporal-worker/tests/test_workflow.py
@@ -1,0 +1,50 @@
+import sys
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+import types
+import core
+
+# Ensure the repository and service directories are on the Python path so we can import modules
+SERVICE_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(SERVICE_DIR))
+sys.path.append(str(REPO_ROOT))
+
+import workflow as wf
+
+
+def test_run_steps_invokes_execute_steps(monkeypatch):
+    fake_exec = MagicMock(return_value={"ok": True})
+    stub = types.ModuleType("agentControl")
+    stub.execute_steps = fake_exec
+    monkeypatch.setitem(sys.modules, "core.agentControl", stub)
+    inp = wf.AgentWorkflowInput(
+        prompt="p", steps=[{"tool": "t", "args": {}}], thread="th", tags=None
+    )
+    result = wf.run_steps(inp)
+    fake_exec.assert_called_once_with(
+        "p", [{"tool": "t", "args": {}}], thread_id="th", tags=[]
+    )
+    assert result == {"ok": True}
+
+
+def test_agent_workflow_runs_activity(monkeypatch):
+    async_mock = AsyncMock(return_value={"res": 1})
+    monkeypatch.setattr(wf.workflow, "execute_activity", async_mock)
+    inp = wf.AgentWorkflowInput(prompt="p", steps=[])
+    result = asyncio.run(wf.AgentWorkflow().run(inp))
+    async_mock.assert_awaited_once()
+    args, kwargs = async_mock.call_args
+    assert args == (wf.run_steps, inp)
+    assert kwargs == {"schedule_to_close_timeout": wf.timedelta(minutes=10)}
+    assert result == {"res": 1}
+
+
+def test_agent_workflow_activity_failure(monkeypatch):
+    async_mock = AsyncMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(wf.workflow, "execute_activity", async_mock)
+    inp = wf.AgentWorkflowInput(prompt="p", steps=[])
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(wf.AgentWorkflow().run(inp))


### PR DESCRIPTION
## Summary
- test workflow activity execution and failure handling
- test Temporal worker startup logic and error propagation
- install temporal-worker requirements in CI so tests run

## Testing
- `pytest services/temporal-worker/tests -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pdfminer')*

------
https://chatgpt.com/codex/tasks/task_e_689d1d70ec408325b655e691d6267358