### PR TITLE
Add tests for autoagent core and utilities

### DIFF
--- a/apps/autoagent-core/autoagent/tests/conftest.py
+++ b/apps/autoagent-core/autoagent/tests/conftest.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import types
+
+# Ensure package path
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if BASE_DIR not in sys.path:
+    sys.path.insert(0, BASE_DIR)
+
+# Stub heavy optional modules that may not be installed
+sys.modules.setdefault('autoagent.tools', types.ModuleType('tools'))
+sys.modules.setdefault('autoagent.agents', types.ModuleType('agents'))
+sys.modules.setdefault('autoagent.workflows', types.ModuleType('workflows'))
+
+import pytest
+from autoagent.types import Agent, Result
+from autoagent.core import MetaChain
+
+
+@pytest.fixture
+def sample_tool():
+    def add(a: int, b: int, context_variables: dict | None = None):
+        return Result(value=str(a + b), context_variables={'sum': a + b})
+    return add
+
+
+@pytest.fixture
+def sample_agent(sample_tool):
+    return Agent(
+        name='adder',
+        model='gpt-4o',
+        instructions='Add numbers',
+        functions=[sample_tool],
+    )
+
+
+@pytest.fixture
+def mc():
+    return MetaChain()

--- a/apps/autoagent-core/autoagent/tests/test_core.py
+++ b/apps/autoagent-core/autoagent/tests/test_core.py
@@ -1,0 +1,45 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+from tenacity import Retrying, stop_after_attempt, wait_none, retry_if_exception
+from litellm.exceptions import APIError
+from litellm.types.utils import Function, ChatCompletionMessageToolCall
+
+from autoagent.core import MetaChain, should_retry_error
+from autoagent.types import Agent, Result
+
+
+def test_handle_tool_calls_executes_function_and_updates_context(mc, sample_agent):
+    tool_call = ChatCompletionMessageToolCall(
+        id='1',
+        type='tool',
+        function=Function(name='add', arguments=json.dumps({'a': 1, 'b': 2}))
+    )
+    response = mc.handle_tool_calls([tool_call], sample_agent.functions, {}, debug=False)
+    assert response.messages[0]['content'] == '3'
+    assert response.context_variables['sum'] == 3
+
+
+def test_get_chat_completion_retries_on_api_error(monkeypatch):
+    agent = Agent(name='test', model='gpt-4o', instructions='hi', functions=[])
+    call_count = {'n': 0}
+
+    class DummyCompletion:
+        def __init__(self):
+            self.choices = [SimpleNamespace(message=SimpleNamespace(content='ok'))]
+
+    def fake_completion(**kwargs):
+        call_count['n'] += 1
+        if call_count['n'] < 2:
+            raise APIError(500, 'boom', 'test', 'gpt-4o')
+        return DummyCompletion()
+
+    monkeypatch.setattr('autoagent.core.completion', fake_completion)
+    monkeypatch.setattr('autoagent.core.litellm.supports_function_calling', lambda model: True)
+
+    mc = MetaChain()
+    retryer = Retrying(stop=stop_after_attempt(2), wait=wait_none(), retry=retry_if_exception(should_retry_error), reraise=True)
+    completion = retryer(mc.get_chat_completion, agent=agent, history=[], context_variables={}, model_override=None, stream=False, debug=False)
+    assert call_count['n'] == 2
+    assert completion.choices[0].message.content == 'ok'

--- a/apps/autoagent-core/autoagent/tests/test_server.py
+++ b/apps/autoagent-core/autoagent/tests/test_server.py
@@ -1,0 +1,60 @@
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from autoagent.types import Agent, Response
+from autoagent.registry import registry, register_tool, register_agent
+
+
+@pytest.fixture(scope='module')
+def client():
+    import autoagent.server as server
+    importlib.reload(server)
+    from fastapi import FastAPI
+    server.app = FastAPI()
+    app = server.app
+
+    # clear registry
+    registry._registry['tools'].clear()
+    registry._registry['agents'].clear()
+    registry._registry_info['tools'].clear()
+    registry._registry_info['agents'].clear()
+
+    @register_tool(name='echo')
+    def echo(text: str):
+        return text
+
+    @register_agent(name='echo_agent', func_name='echo_agent')
+    def make_agent(model: str):
+        return Agent(name='echo_agent', model=model, instructions='echo', functions=[])
+
+    # Manually create endpoints on the new app
+    server.create_tool_endpoints()
+    server.create_agent_endpoints()
+
+    def fake_run(self, agent, messages, context_storage=None, **kwargs):
+        return Response(messages=[{'role': 'assistant', 'content': 'ok'}], agent=agent, context_variables={})
+
+    from unittest.mock import patch
+    with patch('autoagent.core.MetaChain.run', fake_run):
+        with TestClient(app) as c:
+            yield c
+
+
+def test_tool_endpoint(client):
+    resp = client.post('/tools/echo', json={'args': {'text': 'hi'}})
+    assert resp.status_code == 200
+    assert resp.json()['result'] == 'hi'
+
+    resp2 = client.post('/tools/echo', json={'args': {}})
+    assert resp2.status_code == 400
+
+
+def test_agent_endpoint(client):
+    payload = {'model': 'test', 'query': 'hi', 'context_variables': {}}
+    resp = client.post('/agents/echo_agent/run', json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body['result'] == 'ok'
+    assert body['agent_name'] == 'echo_agent'

--- a/apps/autoagent-core/autoagent/tests/test_types.py
+++ b/apps/autoagent-core/autoagent/tests/test_types.py
@@ -1,0 +1,20 @@
+from autoagent.types import Agent, Response, Result
+
+
+def test_agent_defaults():
+    agent = Agent()
+    assert agent.model == 'gpt-4o'
+    assert 'helpful agent' in agent.instructions
+
+
+def test_response_instances_isolated():
+    r1 = Response()
+    r2 = Response()
+    r1.messages.append({'role': 'assistant', 'content': 'hi'})
+    assert r2.messages == []
+
+
+def test_result_fields():
+    res = Result(value='ok', context_variables={'a': 1})
+    assert res.value == 'ok'
+    assert res.context_variables['a'] == 1

--- a/apps/autoagent-core/autoagent/tests/test_util.py
+++ b/apps/autoagent-core/autoagent/tests/test_util.py
@@ -1,0 +1,45 @@
+import json
+from autoagent.util import function_to_json, merge_chunk
+
+
+def sample_func(a: int, b: str) -> None:
+    """Sample function"""
+    return None
+
+
+def test_function_to_json_basic():
+    info = function_to_json(sample_func)
+    func_info = info['function']
+    assert func_info['name'] == 'sample_func'
+    params = func_info['parameters']['properties']
+    assert params['a']['type'] == 'integer'
+    assert params['b']['type'] == 'string'
+    assert set(func_info['parameters']['required']) == {'a', 'b'}
+
+
+def test_merge_chunk_with_tool_calls():
+    message = {
+        'content': '',
+        'tool_calls': {
+            0: {
+                'function': {'arguments': '', 'name': ''},
+                'id': '',
+                'type': ''
+            }
+        }
+    }
+    delta = {
+        'content': 'Hello',
+        'tool_calls': [
+            {
+                'index': 0,
+                'function': {'arguments': '{}', 'name': 'do'},
+                'id': '1',
+                'type': 'tool'
+            }
+        ]
+    }
+    merge_chunk(message, delta)
+    assert message['content'] == 'Hello'
+    assert message['tool_calls'][0]['function']['name'] == 'do'
+    assert message['tool_calls'][0]['id'] == '1'

--- a/apps/autoagent-core/pyproject.toml
+++ b/apps/autoagent-core/pyproject.toml
@@ -1,3 +1,15 @@
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "fastapi",
+    "httpx",
+    "tenacity",
+    "litellm",
+]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["autoagent/tests"]


### PR DESCRIPTION
## Summary
- add unit tests for MetaChain tool calls and retry logic
- cover FastAPI server endpoints and utilities
- configure pytest and test dependencies

## Testing
- `pytest apps/autoagent-core/autoagent/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_689d1d6f9e5c832586812534963a511f