### PR TITLE
feat: add automatic code language detection

### DIFF
--- a/libs/llamaindex/llama-index-core/tests/text_splitter/test_code_splitter.py
+++ b/libs/llamaindex/llama-index-core/tests/text_splitter/test_code_splitter.py
@@ -208,3 +208,21 @@ def baz():
     chunks = code_splitter.split_text(text)
     assert chunks[0].startswith("def foo():")
     assert chunks[1].startswith("def baz():")
+
+
+@pytest.mark.skipif(SHOULD_SKIP, reason="tree_sitter not installed")
+def test_auto_detect_language_code_splitter() -> None:
+    """CodeSplitter should detect language when none is provided."""
+    if "CI" in os.environ:
+        return
+
+    code_splitter = CodeSplitter(chunk_lines=4, chunk_lines_overlap=1, max_chars=30)
+
+    text = """\
+def foo():
+    print("bar")
+"""
+
+    chunks = code_splitter.split_text(text)
+    assert code_splitter.language == "python"
+    assert chunks[0].startswith("def foo():")


### PR DESCRIPTION
## Summary
- integrate automatic language detection for code splitting, falling back to Pygments when Guesslang unavailable
- select tree-sitter parser based on detected language
- test auto-detection path in CodeSplitter

## Testing
- `python -m py_compile libs/llamaindex/llama-index-core/llama_index/core/node_parser/text/code.py libs/llamaindex/llama-index-core/tests/text_splitter/test_code_splitter.py`
- `PYTHONPATH=libs/llamaindex/llama-index-core:libs/llamaindex/llama-index-instrumentation/src:$PYTHONPATH pytest libs/llamaindex/llama-index-core/tests/text_splitter/test_code_splitter.py::test_auto_detect_language_code_splitter -q` *(fails: ModuleNotFoundError: No module named 'workflows')*


------
https://chatgpt.com/codex/tasks/task_e_689de4cc10d08325b50c29df6ee59237