### PR TITLE
Clarify prompt function variable mapping semantics

### DIFF
--- a/libs/llamaindex/llama-index-core/llama_index/core/prompts/base.py
+++ b/libs/llamaindex/llama-index-core/llama_index/core/prompts/base.py
@@ -68,8 +68,9 @@ class BasePromptTemplate(BaseModel, ABC):  # type: ignore[no-redef]
         default_factory=dict,  # type: ignore
         description=(
             "Function mappings (Optional). This is a mapping from template "
-            "variable names to functions that take in the current kwargs and "
-            "return a string."
+            "variable names to callables. Each callable receives the combined "
+            "set of runtime and fixed kwargs and returns the value for its "
+            "corresponding template variable."
         ),
     )
 
@@ -78,44 +79,42 @@ class BasePromptTemplate(BaseModel, ABC):  # type: ignore[no-redef]
         template_var_mappings = self.template_var_mappings or {}
         return {template_var_mappings.get(k, k): v for k, v in kwargs.items()}
 
-    def _map_function_vars(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    def _map_prompt_func_vars(self, all_kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """
-        For keys in function_mappings, compute values and combine w/ kwargs.
+        Map function-based variables using combined kwargs.
 
-        Users can pass in functions instead of fixed values as format variables.
-        For each function, we call the function with the current kwargs,
-        get back the value, and then use that value in the template
-        for the corresponding format variable.
-
+        The callable for each entry in ``function_mappings`` is invoked with
+        the union of runtime kwargs supplied at formatting time and any fixed
+        kwargs stored on the template. Runtime kwargs override fixed ones when
+        both are present. The return value of each callable replaces the
+        corresponding key in the final kwargs used for formatting.
         """
         function_mappings = self.function_mappings or {}
-        # first generate the values for the functions
-        new_kwargs = {}
-        for k, v in function_mappings.items():
-            # TODO: figure out what variables to pass into each function
-            # is it the kwargs specified during query time? just the fixed kwargs?
-            # all kwargs?
-            new_kwargs[k] = v(**kwargs)
+        new_kwargs: Dict[str, Any] = {}
 
-        # then, add the fixed variables only if not in new_kwargs already
-        # (implying that function mapping will override fixed variables)
-        for k, v in kwargs.items():
-            if k not in new_kwargs:
-                new_kwargs[k] = v
+        # Call the mapping functions with the combined kwargs
+        for key, func in function_mappings.items():
+            new_kwargs[key] = func(**all_kwargs)
+
+        # Include any kwargs not overridden by function mappings
+        for key, val in all_kwargs.items():
+            if key not in new_kwargs:
+                new_kwargs[key] = val
 
         return new_kwargs
 
-    def _map_all_vars(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    def _map_all_vars(self, all_kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """
         Map both template and function variables.
 
-        We (1) first call function mappings to compute functions,
-        and then (2) call the template_var_mappings.
-
+        ``all_kwargs`` should contain the combination of fixed kwargs from the
+        template and any runtime kwargs provided at format time. We first apply
+        ``function_mappings`` using this combined set and then apply
+        ``template_var_mappings`` to the result.
         """
-        # map function
-        new_kwargs = self._map_function_vars(kwargs)
-        # map template vars (to point to existing format vars in string template)
+        # map function variables first
+        new_kwargs = self._map_prompt_func_vars(all_kwargs)
+        # then map template vars (pointing to existing format vars in string template)
         return self._map_template_vars(new_kwargs)
 
     @abstractmethod


### PR DESCRIPTION
## Summary
- rename and document `_map_prompt_func_vars`
- ensure function mappings receive combined runtime and fixed kwargs

## Testing
- `pre-commit run --files llama-index-core/llama_index/core/prompts/base.py`
- `pytest libs/llamaindex/llama-index-core/tests/prompts/test_base.py libs/llamaindex/llama-index-core/tests/prompts/test_rich.py -q` *(fails: ModuleNotFoundError: No module named 'workflows.checkpointer')*

------
https://chatgpt.com/codex/tasks/task_e_689de4ceada883259d880d1165675aac