### PR TITLE
Refactor refine synthesizer to use schema refinement helpers

### DIFF
--- a/libs/llamaindex/llama-index-core/llama_index/core/response_synthesizers/refine.py
+++ b/libs/llamaindex/llama-index-core/llama_index/core/response_synthesizers/refine.py
@@ -10,10 +10,9 @@ from typing import (
     AsyncGenerator,
 )
 
-from llama_index.core.bridge.pydantic import BaseModel, Field, ValidationError
+from llama_index.core.bridge.pydantic import BaseModel, ValidationError
 from llama_index.core.callbacks.base import CallbackManager
 from llama_index.core.indices.prompt_helper import PromptHelper
-from llama_index.core.indices.utils import truncate_text
 from llama_index.core.llms import LLM
 from llama_index.core.prompts.base import BasePromptTemplate
 from llama_index.core.prompts.default_prompt_selectors import (
@@ -21,37 +20,22 @@ from llama_index.core.prompts.default_prompt_selectors import (
     DEFAULT_TEXT_QA_PROMPT_SEL,
 )
 from llama_index.core.prompts.mixin import PromptDictType
-from llama_index.core.response.utils import get_response_text, aget_response_text
 from llama_index.core.response_synthesizers.base import BaseSynthesizer
 from llama_index.core.types import RESPONSE_TEXT_TYPE, BasePydanticProgram
 from llama_index.core.instrumentation.events.synthesis import (
     GetResponseEndEvent,
     GetResponseStartEvent,
 )
+from llama_index.core.base.response.schema import (
+    StructuredRefineResponse,
+    refinement_loop,
+)
+from llama_index.core.async_utils import asyncio_run
 import llama_index.core.instrumentation as instrument
 
 dispatcher = instrument.get_dispatcher(__name__)
 
 logger = logging.getLogger(__name__)
-
-
-class StructuredRefineResponse(BaseModel):
-    """
-    Used to answer a given query based on the provided context.
-
-    Also indicates if the query was satisfied with the provided answer.
-    """
-
-    answer: str = Field(
-        description="The answer for the given query, based on the context and not "
-        "prior knowledge."
-    )
-    query_satisfied: bool = Field(
-        description="True if there was enough context given to provide an answer "
-        "that satisfies the query."
-    )
-
-
 class DefaultRefineProgram(BasePydanticProgram):
     """
     Runs the query on the LLM as normal and always returns the answer with
@@ -280,72 +264,21 @@ class Refine(BaseSynthesizer):
         **response_kwargs: Any,
     ) -> Optional[RESPONSE_TEXT_TYPE]:
         """Refine response."""
-        # TODO: consolidate with logic in response/schema.py
-        if isinstance(response, Generator):
-            response = get_response_text(response)
-
-        fmt_text_chunk = truncate_text(text_chunk, 50)
-        logger.debug(f"> Refine context: {fmt_text_chunk}")
-        if self._verbose:
-            print(f"> Refine context: {fmt_text_chunk}")
-
-        # NOTE: partial format refine template with query_str and existing_answer here
-        refine_template = self._refine_template.partial_format(
-            query_str=query_str, existing_answer=response
+        return asyncio_run(
+            refinement_loop(
+                self._program_factory,
+                self._llm,
+                self._prompt_helper,
+                self._refine_template,
+                response,
+                query_str,
+                text_chunk,
+                self._streaming,
+                self._verbose,
+                False,
+                **response_kwargs,
+            )
         )
-
-        # compute available chunk size to see if there is any available space
-        # determine if the refine template is too big (which can happen if
-        # prompt template + query + existing answer is too large)
-        avail_chunk_size = self._prompt_helper._get_available_chunk_size(
-            refine_template
-        )
-
-        if avail_chunk_size < 0:
-            # if the available chunk size is negative, then the refine template
-            # is too big and we just return the original response
-            return response
-
-        # obtain text chunks to add to the refine template
-        text_chunks = self._prompt_helper.repack(
-            refine_template, text_chunks=[text_chunk], llm=self._llm
-        )
-
-        program = self._program_factory(refine_template)
-        for cur_text_chunk in text_chunks:
-            query_satisfied = False
-            if not self._streaming:
-                try:
-                    structured_response = cast(
-                        StructuredRefineResponse,
-                        program(
-                            context_msg=cur_text_chunk,
-                            **response_kwargs,
-                        ),
-                    )
-                    query_satisfied = structured_response.query_satisfied
-                    if query_satisfied:
-                        response = structured_response.answer
-                except ValidationError as e:
-                    logger.warning(
-                        f"Validation error on structured response: {e}", exc_info=True
-                    )
-            else:
-                # TODO: structured response not supported for streaming
-                if isinstance(response, Generator):
-                    response = "".join(response)
-
-                refine_template = self._refine_template.partial_format(
-                    query_str=query_str, existing_answer=response
-                )
-
-                response = self._llm.stream(
-                    refine_template,
-                    context_msg=cur_text_chunk,
-                    **response_kwargs,
-                )
-
-        return response
 
     @dispatcher.span
     async def aget_response(
@@ -391,80 +324,19 @@ class Refine(BaseSynthesizer):
         **response_kwargs: Any,
     ) -> Optional[RESPONSE_TEXT_TYPE]:
         """Refine response."""
-        # TODO: consolidate with logic in response/schema.py
-        if isinstance(response, AsyncGenerator):
-            response = await aget_response_text(response)
-
-        fmt_text_chunk = truncate_text(text_chunk, 50)
-        logger.debug(f"> Refine context: {fmt_text_chunk}")
-
-        # NOTE: partial format refine template with query_str and existing_answer here
-        refine_template = self._refine_template.partial_format(
-            query_str=query_str, existing_answer=response
+        return await refinement_loop(
+            self._program_factory,
+            self._llm,
+            self._prompt_helper,
+            self._refine_template,
+            response,
+            query_str,
+            text_chunk,
+            self._streaming,
+            self._verbose,
+            True,
+            **response_kwargs,
         )
-
-        # compute available chunk size to see if there is any available space
-        # determine if the refine template is too big (which can happen if
-        # prompt template + query + existing answer is too large)
-        avail_chunk_size = self._prompt_helper._get_available_chunk_size(
-            refine_template
-        )
-
-        if avail_chunk_size < 0:
-            # if the available chunk size is negative, then the refine template
-            # is too big and we just return the original response
-            return response
-
-        # obtain text chunks to add to the refine template
-        text_chunks = self._prompt_helper.repack(
-            refine_template, text_chunks=[text_chunk], llm=self._llm
-        )
-
-        program = self._program_factory(refine_template)
-        for cur_text_chunk in text_chunks:
-            query_satisfied = False
-            if not self._streaming:
-                try:
-                    structured_response = await program.acall(
-                        context_msg=cur_text_chunk,
-                        **response_kwargs,
-                    )
-                    structured_response = cast(
-                        StructuredRefineResponse, structured_response
-                    )
-                    query_satisfied = structured_response.query_satisfied
-                    if query_satisfied:
-                        response = structured_response.answer
-                except ValidationError as e:
-                    logger.warning(
-                        f"Validation error on structured response: {e}", exc_info=True
-                    )
-            else:
-                if isinstance(response, Generator):
-                    response = "".join(response)
-
-                if isinstance(response, AsyncGenerator):
-                    _r = ""
-                    async for text in response:
-                        _r += text
-                    response = _r
-
-                refine_template = self._refine_template.partial_format(
-                    query_str=query_str, existing_answer=response
-                )
-
-                response = await self._llm.astream(
-                    refine_template,
-                    context_msg=cur_text_chunk,
-                    **response_kwargs,
-                )
-
-            if query_satisfied:
-                refine_template = self._refine_template.partial_format(
-                    query_str=query_str, existing_answer=response
-                )
-
-        return response
 
     async def _agive_response_single(
         self,


### PR DESCRIPTION
## Summary
- centralize StructuredRefineResponse and refinement_loop in base response schema
- reuse schema refinement loop from response.synthesizer Refine implementation

## Testing
- `pytest tests/response_synthesizers/test_refine.py -q` *(fails: No module named 'workflows.checkpointer')*


------
https://chatgpt.com/codex/tasks/task_e_689de4d10dd08325810edd92d52a5229