### PR TITLE
Track tool request outcomes in metrics

### DIFF
--- a/core/observability/metrics.py
+++ b/core/observability/metrics.py
@@ -2,85 +2,72 @@ from typing import Dict, Tuple
 
 # Try to use Prometheus if available for richer metrics and test compatibility
 try:
-	from prometheus_client import Counter as PromCounter, Histogram as PromHistogram  # type: ignore
-	_PROM = True
+    from prometheus_client import Counter as PromCounter, Histogram as PromHistogram  # type: ignore
+    _PROM = True
 except Exception:  # pragma: no cover - optional dep
-	PromCounter = None  # type: ignore
-	PromHistogram = None  # type: ignore
-	_PROM = False
-
-# Provide a registry shim that tests can monkeypatch
-class _RegistryShim:
-	def get(self, name: str):  # pragma: no cover - overridden in tests
-		raise KeyError("missing")
-
-registry = _RegistryShim()  # type: ignore
+    PromCounter = None  # type: ignore
+    PromHistogram = None  # type: ignore
+    _PROM = False
 
 
 class _LabelledCounter:
-	def __init__(self, store: Dict[Tuple[str, ...], int], label_values: Tuple[str, ...]):
-		self._store = store
-		self._label_values = label_values
-	def inc(self, amount: int = 1) -> None:
-		self._store[self._label_values] = self._store.get(self._label_values, 0) + amount
+    def __init__(self, store: Dict[Tuple[str, ...], int], label_values: Tuple[str, ...]):
+        self._store = store
+        self._label_values = label_values
+
+    def inc(self, amount: int = 1) -> None:
+        self._store[self._label_values] = self._store.get(self._label_values, 0) + amount
+
 
 class _LabelledHistogram:
-	def __init__(self, store: Dict[Tuple[str, ...], list], label_values: Tuple[str, ...]):
-		self._store = store
-		self._label_values = label_values
-	def observe(self, value: float) -> None:
-		self._store.setdefault(self._label_values, []).append(value)
+    def __init__(self, store: Dict[Tuple[str, ...], list], label_values: Tuple[str, ...]):
+        self._store = store
+        self._label_values = label_values
+
+    def observe(self, value: float) -> None:
+        self._store.setdefault(self._label_values, []).append(value)
+
 
 class Counter:
-	def __init__(self, name: str, description: str, labels: list[str]):
-		self._name = name
-		self._description = description
-		self._labels = labels
-		self._data: Dict[Tuple[str, ...], int] = {}
-	def labels(self, *label_values: str):  # type: ignore[override]
-		return _LabelledCounter(self._data, tuple(label_values))
+    def __init__(self, name: str, description: str, labels: list[str]):
+        self._name = name
+        self._description = description
+        self._labels = labels
+        self._data: Dict[Tuple[str, ...], int] = {}
+
+    def labels(self, *label_values: str):  # type: ignore[override]
+        return _LabelledCounter(self._data, tuple(label_values))
+
 
 class Histogram:
-	def __init__(self, name: str, description: str, labels: list[str]):
-		self._name = name
-		self._description = description
-		self._labels = labels
-		self._data: Dict[Tuple[str, ...], list] = {}
-	def labels(self, *label_values: str):  # type: ignore[override]
-		return _LabelledHistogram(self._data, tuple(label_values))
+    def __init__(self, name: str, description: str, labels: list[str]):
+        self._name = name
+        self._description = description
+        self._labels = labels
+        self._data: Dict[Tuple[str, ...], list] = {}
+
+    def labels(self, *label_values: str):  # type: ignore[override]
+        return _LabelledHistogram(self._data, tuple(label_values))
+
 
 # Prefer Prometheus-backed metrics if available
 if _PROM:
-	tool_calls_total = PromCounter("tool_calls_total", "Tool calls", ["tool","ok"])  # type: ignore
-	tool_latency_ms = PromHistogram("tool_latency_ms", "Tool latency (ms)", ["tool"])  # type: ignore
-	tool_skipped_total = PromCounter("tool_skipped_total", "Tool skipped", ["tool","reason"])  # type: ignore
-	tool_requests_total = PromCounter("tool_requests_total", "Tool requests", ["tool","found"])  # type: ignore
-	llm_calls_total = PromCounter("llm_calls_total", "LLM calls", ["model","ok","tags"])  # type: ignore
-	llm_latency_ms = PromHistogram("llm_latency_ms", "LLM latency (ms)", ["model","tags"])  # type: ignore
+    tool_calls_total = PromCounter("tool_calls_total", "Tool calls", ["tool", "ok"])  # type: ignore
+    tool_latency_ms = PromHistogram("tool_latency_ms", "Tool latency (ms)", ["tool"])  # type: ignore
+    tool_skipped_total = PromCounter("tool_skipped_total", "Tool skipped", ["tool", "reason"])  # type: ignore
+    tool_requests_total = PromCounter("tool_requests_total", "Tool requests", ["tool", "status"])  # type: ignore
+    llm_calls_total = PromCounter("llm_calls_total", "LLM calls", ["model", "ok", "tags"])  # type: ignore
+    llm_latency_ms = PromHistogram("llm_latency_ms", "LLM latency (ms)", ["model", "tags"])  # type: ignore
 else:  # lightweight in-process metrics
-	tool_calls_total = Counter("tool_calls_total", "Tool calls", ["tool","ok"])
-	tool_latency_ms = Histogram("tool_latency_ms", "Tool latency (ms)", ["tool"])
-	tool_skipped_total = Counter("tool_skipped_total", "Tool skipped", ["tool","reason"])
-	tool_requests_total = Counter("tool_requests_total", "Tool requests", ["tool","found"])
-	llm_calls_total = Counter("llm_calls_total", "LLM calls", ["model","ok","tags"])  # type: ignore
-	llm_latency_ms = Histogram("llm_latency_ms", "LLM latency (ms)", ["model","tags"])  # type: ignore
+    tool_calls_total = Counter("tool_calls_total", "Tool calls", ["tool", "ok"])
+    tool_latency_ms = Histogram("tool_latency_ms", "Tool latency (ms)", ["tool"])
+    tool_skipped_total = Counter("tool_skipped_total", "Tool skipped", ["tool", "reason"])
+    tool_requests_total = Counter("tool_requests_total", "Tool requests", ["tool", "status"])
+    llm_calls_total = Counter("llm_calls_total", "LLM calls", ["model", "ok", "tags"])  # type: ignore
+    llm_latency_ms = Histogram("llm_latency_ms", "LLM latency (ms)", ["model", "tags"])  # type: ignore
 
 
-def record_tool_request(tool_name: str, found: str | None = None) -> None:
-	"""Record a tool lookup request.
-	
-	If ``found`` is None, attempt to resolve the tool via ``metrics.registry.get``
-	to determine existence. This behavior is compatible with tests that monkeypatch
-	``metrics.registry.get`` to raise ``KeyError`` for missing tools.
-	"""
-	if found is None:
-		try:
-			registry.get(tool_name)  # type: ignore[attr-defined]
-			tool_requests_total.labels(tool_name, "true").inc()  # type: ignore[attr-defined]
-			return
-		except KeyError:
-			tool_requests_total.labels(tool_name, "false").inc()  # type: ignore[attr-defined]
-			raise
-	# explicit path
-	val = "true" if str(found).lower() in ("1","true","yes") or found is True else "false"  # type: ignore
-	tool_requests_total.labels(tool_name, val).inc()  # type: ignore[attr-defined]
+def record_tool_request(tool: str, status: str) -> None:
+    """Record a tool lookup request."""
+    tool_requests_total.labels(tool, status).inc()  # type: ignore[attr-defined]
+

--- a/core/tests/test_metrics.py
+++ b/core/tests/test_metrics.py
@@ -1,4 +1,3 @@
-import pytest
 from prometheus_client import Counter, CollectorRegistry
 
 from core.observability import metrics
@@ -7,7 +6,7 @@ from core.observability import metrics
 def _fresh_counter(monkeypatch):
     registry = CollectorRegistry()
     counter = Counter(
-        "tool_requests_total", "Tool requests", ["tool", "found"], registry=registry
+        "tool_requests_total", "Tool requests", ["tool", "status"], registry=registry
     )
     monkeypatch.setattr(metrics, "tool_requests_total", counter)
     return registry
@@ -15,13 +14,12 @@ def _fresh_counter(monkeypatch):
 
 def test_record_tool_request_found(monkeypatch):
     registry = _fresh_counter(monkeypatch)
-    monkeypatch.setattr(metrics.registry, "get", lambda name: object())
 
-    metrics.record_tool_request("echo")
+    metrics.record_tool_request("echo", "found")
 
     assert (
         registry.get_sample_value(
-            "tool_requests_total", {"tool": "echo", "found": "true"}
+            "tool_requests_total", {"tool": "echo", "status": "found"}
         )
         == 1.0
     )
@@ -30,17 +28,11 @@ def test_record_tool_request_found(monkeypatch):
 def test_record_tool_request_missing(monkeypatch):
     registry = _fresh_counter(monkeypatch)
 
-    def fake_get(_name):
-        raise KeyError("missing")
-
-    monkeypatch.setattr(metrics.registry, "get", fake_get)
-
-    with pytest.raises(KeyError):
-        metrics.record_tool_request("ghost")
+    metrics.record_tool_request("ghost", "not_found")
 
     assert (
         registry.get_sample_value(
-            "tool_requests_total", {"tool": "ghost", "found": "false"}
+            "tool_requests_total", {"tool": "ghost", "status": "not_found"}
         )
         == 1.0
     )

--- a/core/tools/registry.py
+++ b/core/tools/registry.py
@@ -27,9 +27,9 @@ def register(tool: ToolSpec) -> None:
 
 def get(name: str) -> ToolSpec:
     if name not in _REGISTRY:
-        record_tool_request(name, "false")
+        record_tool_request(name, "not_found")
         raise KeyError(f"tool not found: {name}")
-    record_tool_request(name, "true")
+    record_tool_request(name, "found")
     return _REGISTRY[name]
 
 


### PR DESCRIPTION
## Summary
- add `record_tool_request` helper with explicit status argument
- track tool lookup status via `tool_requests_total` counter
- call `record_tool_request` in registry

## Testing
- `PYTHONPATH=. pytest core/tests/test_metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_689deb43afc48325ba788341eb48849e