### PR TITLE
docs: add quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,34 @@
 
+## Quick start
+
+1. **Install dependencies**
+
+   Use any Python package manager to install the project in editable mode:
+
+   ```bash
+   pip install -e .
+   ```
+
+2. **Create a plugin template**
+
+   ```bash
+   python tools/agent_plugin_cli.py plugin create my_plugin
+   ```
+
+   This generates `plugins/my_plugin` with a stub `ToolSpec` implementation.
+
+3. **Enable optional features** (all disabled by default)
+
+   ```bash
+   export TOOL_HOT_RELOAD=true              # dynamic plugin reloads
+   export POLICY_ENGINE_ENABLED=true        # allowlist, FS roots, rate limits
+   export ADVANCED_PLANNING=true            # conditionals/loops in plans
+   ```
+
+   A `hitl.ok` file approves human-in-the-loop pauses when `HITL_DEFAULT=true`.
+
+See [`docs/quickstart.md`](docs/quickstart.md) for more details.
+
 ## Tool registry, policy, HITL, and planning (experimental)
 
 Feature-flagged modules add dynamic tool loading, a policy engine, and advanced planning:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,36 @@
+# Quick start
+
+This guide shows how to try the experimental agent runtime.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+Any Python package manager can be used. The project targets Python 3.10+.
+
+## Creating a plugin
+
+```bash
+python tools/agent_plugin_cli.py plugin create my_plugin
+```
+
+A new folder `plugins/my_plugin` is created with a minimal `ToolSpec` that you
+can extend.
+
+## Enabling optional modules
+
+All advanced features are disabled by default. Enable them with environment variables:
+
+```bash
+export TOOL_HOT_RELOAD=true              # reload plugins without restart
+export POLICY_ENGINE_ENABLED=true        # allowlist, path restrictions, rate limits
+export ADVANCED_PLANNING=true            # plan conditionals and loops
+export HITL_DEFAULT=true                 # require human approvals
+```
+
+A `hitl.ok` file in the repository root approves paused waves when HITL is enabled.
+
+For design details see [`docs/architecture/tool-runtime-and-planning.md`](architecture/tool-runtime-and-planning.md).
+


### PR DESCRIPTION
## Summary
- add top-level quick start guidance for installation, plugin creation, and feature flags
- document details in new `docs/quickstart.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tests.test_readers_docstring_walker', 345 similar)*

------
https://chatgpt.com/codex/tasks/task_e_689e30d73a588325be66e884136cd381