### PR TITLE
feat: scaffold plugins and services via unified agent CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,18 @@
 2. **Create a plugin template**
 
    ```bash
-   python tools/agent_plugin_cli.py plugin create my_plugin
+   python tools/agent_cli.py create plugin my_plugin
    ```
 
    This generates `plugins/my_plugin` with a stub `ToolSpec` implementation.
+
+   To scaffold a new service instead:
+
+   ```bash
+   python tools/agent_cli.py create service my_service
+   ```
+
+   which creates `services/my_service` with a minimal FastAPI app.
 
 3. **Enable optional features** (all disabled by default)
 

--- a/core/tests/test_agent_cli.py
+++ b/core/tests/test_agent_cli.py
@@ -1,0 +1,26 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def run_cli(tmp_path: Path, *args: str) -> subprocess.CompletedProcess:
+    script = Path(__file__).resolve().parents[2] / "tools" / "agent_cli.py"
+    cmd = ["python", str(script), *args, "--root", str(tmp_path)]
+    return subprocess.run(cmd, check=True, text=True, capture_output=True)
+
+
+def test_create_plugin(tmp_path: Path):
+    run_cli(tmp_path, "create", "plugin", "demo")
+    plugin_dir = tmp_path / "plugins" / "demo"
+    assert (plugin_dir / "plugin.json").exists()
+    with open(plugin_dir / "plugin.json", "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+    assert manifest["name"] == "demo"
+    assert (plugin_dir / "demo.py").exists()
+
+
+def test_create_service(tmp_path: Path):
+    run_cli(tmp_path, "create", "service", "demo_service")
+    service_dir = tmp_path / "services" / "demo_service"
+    assert (service_dir / "main.py").exists()
+

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,11 +13,15 @@ Any Python package manager can be used. The project targets Python 3.10+.
 ## Creating a plugin
 
 ```bash
-python tools/agent_plugin_cli.py plugin create my_plugin
+python tools/agent_cli.py create plugin my_plugin
 ```
 
 A new folder `plugins/my_plugin` is created with a minimal `ToolSpec` that you
-can extend.
+can extend. To scaffold a service instead:
+
+```bash
+python tools/agent_cli.py create service my_service
+```
 
 ## Enabling optional modules
 

--- a/tools/agent_cli.py
+++ b/tools/agent_cli.py
@@ -1,0 +1,72 @@
+import argparse
+import json
+from pathlib import Path
+
+TEMPLATE = (
+    "from core.tools.registry import ToolSpec\n\n"
+    "def run(args):\n"
+    "    return {{}}\n\n"
+    "spec = ToolSpec(name=\"{name}\", input_model=None, run=run)\n"
+)
+
+
+def create_plugin(name: str, root: Path) -> None:
+    """Scaffold a basic Python plugin."""
+    plugin_dir = root / "plugins" / name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "name": name,
+        "version": "0.1.0",
+        "entry": f"{name}.py",
+        "scopes": [],
+        "commands": [],
+    }
+    with open(plugin_dir / "plugin.json", "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+    with open(plugin_dir / f"{name}.py", "w", encoding="utf-8") as f:
+        f.write(TEMPLATE.format(name=name))
+    print(f"created plugin template at {plugin_dir}")
+
+
+SERVICE_TEMPLATE = """from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+"""
+
+
+def create_service(name: str, root: Path) -> None:
+    """Scaffold a minimal FastAPI service."""
+    service_dir = root / "services" / name
+    service_dir.mkdir(parents=True, exist_ok=True)
+    with open(service_dir / "main.py", "w", encoding="utf-8") as f:
+        f.write(SERVICE_TEMPLATE)
+    print(f"created service template at {service_dir}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="agent")
+    sub = parser.add_subparsers(dest="cmd")
+
+    create = sub.add_parser("create")
+    create.add_argument("type", choices=["plugin", "service"])
+    create.add_argument("name")
+    create.add_argument("--root", default=".")
+
+    args = parser.parse_args()
+    if args.cmd == "create":
+        root = Path(args.root)
+        if args.type == "plugin":
+            create_plugin(args.name, root)
+        elif args.type == "service":
+            create_service(args.name, root)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/agent_plugin_cli_legacy.py
+++ b/tools/agent_plugin_cli_legacy.py
@@ -1,3 +1,7 @@
+"""Legacy plugin CLI preserved for reference.
+Use tools/agent_cli.py instead.
+"""
+
 import argparse
 import json
 from pathlib import Path
@@ -5,7 +9,7 @@ from pathlib import Path
 TEMPLATE = (
     "from core.tools.registry import ToolSpec\n\n"
     "def run(args):\n"
-    "    return {{}}\n\n"
+    "    return {}\n\n"
     "spec = ToolSpec(name=\"{name}\", input_model=None, run=run)\n"
 )
 


### PR DESCRIPTION
## Summary
- add `agent_cli` script with `create plugin|service` scaffolding
- document CLI usage in README and quickstart
- test CLI plugin and service scaffolding
- retain deprecated `agent_plugin_cli.py` as legacy reference

## Testing
- `pytest core/tests/test_agent_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e32eb3fa483258174327bb894b195