### PR TITLE
Add root packaging and CLI entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS instructions
+
+These guidelines apply to the entire repository.
+
+## Development workflow
+
+- Prefer `rg` for searching within the repo; avoid `ls -R` or `grep -R`.
+- Install the project in editable mode without dependency resolution:
+  
+  ```bash
+  pip install --no-deps -e .
+  ```
+- Ensure the CLI loads:
+  
+  ```bash
+  agent --help
+  ```
+- For any modified Python files, verify they compile:
+  
+  ```bash
+  python -m py_compile <paths>
+  ```
+
+## Documentation
+
+- Update `README.md` and `docs/quickstart.md` whenever user-facing commands change.
+- Reference this `AGENTS.md` for contributor guidelines.
+
+## Commit style
+
+- Use imperative mood in commit messages.
+- Leave the worktree clean before finalizing (`git status` should show no changes).

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
    Use any Python package manager to install the project in editable mode:
 
    ```bash
-   pip install -e .
+   pip install --no-deps -e .
    ```
 
 2. **Create a plugin template**
 
    ```bash
-   python tools/agent_cli.py create plugin my_plugin
+   agent create plugin my_plugin
    ```
 
    This generates `plugins/my_plugin` with a stub `ToolSpec` implementation.
@@ -20,7 +20,7 @@
    To scaffold a new service instead:
 
    ```bash
-   python tools/agent_cli.py create service my_service
+   agent create service my_service
    ```
 
    which creates `services/my_service` with a minimal FastAPI app.
@@ -47,3 +47,7 @@ Feature-flagged modules add dynamic tool loading, a policy engine, and advanced 
 - Planning: `core.planning.advanced` enables conditional/loop expansion; `core.planning.reflection` adds checkpoints.
 
 All are disabled by default. See `docs/architecture/tool-runtime-and-planning.md`.
+
+---
+
+For development conventions and testing commands, see [AGENTS.md](AGENTS.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ This guide shows how to try the experimental agent runtime.
 ## Installation
 
 ```bash
-pip install -e .
+pip install --no-deps -e .
 ```
 
 Any Python package manager can be used. The project targets Python 3.10+.
@@ -13,14 +13,14 @@ Any Python package manager can be used. The project targets Python 3.10+.
 ## Creating a plugin
 
 ```bash
-python tools/agent_cli.py create plugin my_plugin
+agent create plugin my_plugin
 ```
 
 A new folder `plugins/my_plugin` is created with a minimal `ToolSpec` that you
 can extend. To scaffold a service instead:
 
 ```bash
-python tools/agent_cli.py create service my_service
+agent create service my_service
 ```
 
 ## Enabling optional modules
@@ -37,4 +37,6 @@ export HITL_DEFAULT=true                 # require human approvals
 A `hitl.ok` file in the repository root approves paused waves when HITL is enabled.
 
 For design details see [`docs/architecture/tool-runtime-and-planning.md`](architecture/tool-runtime-and-planning.md).
+
+For development guidelines, consult [AGENTS.md](../AGENTS.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agent-mono"
+version = "0.1.0"
+description = "Experimental agent runtime monorepo"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+agent = "tools.agent_cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["core*", "tools*"]

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line utilities and helpers for the agent runtime."""

--- a/tools/agent_cli.py
+++ b/tools/agent_cli.py
@@ -2,14 +2,24 @@ import argparse
 import json
 from pathlib import Path
 
-from agent_extensions import (
-    flow_augment,
-    flow_validate,
-    generate_tests,
-    instrument_code,
-    release_prep,
-    secure_plugin,
-)
+try:
+    from .agent_extensions import (
+        flow_augment,
+        flow_validate,
+        generate_tests,
+        instrument_code,
+        release_prep,
+        secure_plugin,
+    )
+except ImportError:  # pragma: no cover
+    from agent_extensions import (  # type: ignore
+        flow_augment,
+        flow_validate,
+        generate_tests,
+        instrument_code,
+        release_prep,
+        secure_plugin,
+    )
 
 TEMPLATE = (
     "from core.tools.registry import ToolSpec\n\n"


### PR DESCRIPTION
## Summary
- package the monorepo with pyproject.toml and expose an `agent` CLI entry point
- import utilities with package-safe relative imports
- document using the new `agent` command in README and quickstart
- capture repo conventions in a root `AGENTS.md`

## Testing
- `pip install --no-deps -e .`
- `agent --help`
- `python -m py_compile tools/agent_cli.py tools/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_689e3ef10134832591020f177fdbfce1