### PR TITLE
test: cover tool request metric

### DIFF
--- a/core/observability/metrics.py
+++ b/core/observability/metrics.py
@@ -1,3 +1,41 @@
+"""Prometheus metrics helpers."""
+
 from prometheus_client import Counter, Histogram
-tool_calls_total = Counter("tool_calls_total", "Tool calls", ["tool","ok"])
+
+from core.tools import registry
+
+
+# Metric tracking the total number of tool calls and their success.
+tool_calls_total = Counter("tool_calls_total", "Tool calls", ["tool", "ok"])
 tool_latency_ms = Histogram("tool_latency_ms", "Tool latency (ms)", ["tool"])
+
+# Metric tracking whether a requested tool was found in the registry.
+tool_requests_total = Counter(
+    "tool_requests_total", "Tool requests", ["tool", "found"],
+)
+
+
+def record_tool_request(name: str) -> None:
+    """Record a request for a tool.
+
+    Parameters
+    ----------
+    name:
+        The name of the tool being requested.
+
+    The function consults the global tool ``registry``.  If the tool exists the
+    counter is incremented with ``found=true``.  If the tool is missing the
+    counter is incremented with ``found=false`` and the ``KeyError`` is re-raised
+    so callers can handle the missing tool appropriately.
+    """
+
+    try:
+        registry.get(name)
+    except KeyError:
+        # Increment metric for missing tools before propagating the error.
+        tool_requests_total.labels(tool=name, found="false").inc()
+        raise
+    else:
+        # Tool found in registry.
+        tool_requests_total.labels(tool=name, found="true").inc()
+

--- a/core/tests/test_metrics.py
+++ b/core/tests/test_metrics.py
@@ -1,0 +1,48 @@
+import pytest
+from prometheus_client import Counter, CollectorRegistry
+
+from core.observability import metrics
+
+
+def _setup_counter(monkeypatch):
+    registry = CollectorRegistry()
+    counter = Counter(
+        "tool_requests_total", "Tool requests", ["tool", "found"], registry=registry
+    )
+    monkeypatch.setattr(metrics, "tool_requests_total", counter)
+    return registry
+
+
+def test_record_tool_request_found(monkeypatch):
+    registry = _setup_counter(monkeypatch)
+
+    # Simulate a tool existing in the registry
+    monkeypatch.setattr(metrics.registry, "get", lambda name: object())
+
+    metrics.record_tool_request("example")
+
+    assert (
+        registry.get_sample_value(
+            "tool_requests_total", {"tool": "example", "found": "true"}
+        )
+        == 1
+    )
+
+
+def test_record_tool_request_missing(monkeypatch):
+    registry = _setup_counter(monkeypatch)
+
+    def _missing(name):
+        raise KeyError(name)
+
+    monkeypatch.setattr(metrics.registry, "get", _missing)
+
+    with pytest.raises(KeyError):
+        metrics.record_tool_request("missing")
+
+    assert (
+        registry.get_sample_value(
+            "tool_requests_total", {"tool": "missing", "found": "false"}
+        )
+        == 1
+    )


### PR DESCRIPTION
## Summary
- track whether requested tools are found with `record_tool_request`
- add unit tests for tool request metric

## Testing
- `PYTHONPATH=. pytest core/tests/test_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d1f636a5c83259f3d1c9316acd6b2