### PR TITLE
Document project scope and integration tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ All are disabled by default. See `docs/architecture/tool-runtime-and-planning.md
 ---
 
 For development conventions and testing commands, see [AGENTS.md](AGENTS.md).
+
+For an overview of outstanding work and integration plans, see [docs/project-scope.md](docs/project-scope.md).

--- a/docs/project-scope.md
+++ b/docs/project-scope.md
@@ -1,0 +1,36 @@
+# Project scope and integration roadmap
+
+This document outlines the remaining work to fully integrate the experimental agent runtime, tool plugins, and service suite.
+
+## Existing components
+- **CLI and scaffolding**: `agent create` generates plugin and service templates.
+- **Core runtime**: modules under `core/` provide tool registry, policy engine, planning, memory, and observability.
+- **Services**: example Temporal worker in `services/temporal-worker` executes workflows against the core runtime.
+- **Docs**: quickstart, architecture, and tool/policy guides describe basic usage and feature flags.
+
+## Outstanding work
+1. **Documentation**
+   - Add guides for developing plugins and deploying services.
+   - Expand policy and configuration references for production setups.
+   - Describe observability, logging, and tracing options.
+2. **Tool integration**
+   - Audit existing plugins for completeness and error handling.
+   - Expose remote tool registration through configuration and CLI helpers.
+   - Harden sandboxing for risky tools and enforce rate limits consistently.
+3. **Service orchestration**
+   - Flesh out the Temporal worker example into a reusable service package.
+   - Document how services discover plugins and share policy settings.
+   - Provide deployment examples (Docker, compose, and cloud workflows).
+4. **Planning and HITL**
+   - Stabilize advanced planning features and reflection checkpoints.
+   - Improve human‑in‑the‑loop flows and document approval mechanisms.
+5. **Testing and quality**
+   - Increase unit and integration test coverage for registry, policy, and planning modules.
+   - Add end‑to‑end scenarios that exercise plugin, service, and workflow interactions.
+
+## Next steps
+1. Draft plugin and service development guides.
+2. Build deployment examples demonstrating tool integration across services.
+3. Expand automated tests and observability to validate the full suite.
+
+For contributor guidelines, see [AGENTS.md](../AGENTS.md). Existing usage docs remain in [README.md](../README.md) and [docs/quickstart.md](quickstart.md).

--- a/libs/llamaindex/llama-index-core/llama_index/core/base/response/schema.py
+++ b/libs/llamaindex/llama-index-core/llama_index/core/base/response/schema.py
@@ -13,6 +13,7 @@ from typing import (
     Callable,
     Generator,
     AsyncGenerator,
+    Awaitable,
     cast,
 )
 
@@ -367,3 +368,73 @@ async def refinement_loop(
             response = await stream_response(refine_template, cur_text_chunk)
 
     return response
+
+
+def refine_program_loop(
+    response: RESPONSE_TEXT_TYPE,
+    query_str: str,
+    text_chunk: str,
+    *,
+    program_factory: Callable[["BasePromptTemplate"], "BasePydanticProgram"],
+    stream_fn: Callable[["BasePromptTemplate", str, Any], Awaitable[RESPONSE_TEXT_TYPE]],
+    base_refine_template: "BasePromptTemplate",
+    prompt_helper: "PromptHelper",
+    llm: "LLM",
+    streaming: bool,
+    verbose: bool,
+    response_kwargs: Dict[str, Any],
+) -> Optional[RESPONSE_TEXT_TYPE]:
+    """Synchronous wrapper for ``refinement_loop``.
+
+    ``stream_fn`` is accepted for API compatibility but is not used directly.
+    """
+
+    return asyncio_run(
+        refinement_loop(
+            program_factory,
+            llm,
+            prompt_helper,
+            base_refine_template,
+            response,
+            query_str,
+            text_chunk,
+            streaming,
+            verbose,
+            False,
+            **response_kwargs,
+        )
+    )
+
+
+async def arefine_program_loop(
+    response: RESPONSE_TEXT_TYPE,
+    query_str: str,
+    text_chunk: str,
+    *,
+    program_factory: Callable[["BasePromptTemplate"], "BasePydanticProgram"],
+    stream_fn: Callable[["BasePromptTemplate", str, Any], Awaitable[RESPONSE_TEXT_TYPE]],
+    base_refine_template: "BasePromptTemplate",
+    prompt_helper: "PromptHelper",
+    llm: "LLM",
+    streaming: bool,
+    verbose: bool,
+    response_kwargs: Dict[str, Any],
+) -> Optional[RESPONSE_TEXT_TYPE]:
+    """Async wrapper for ``refinement_loop``.
+
+    ``stream_fn`` is accepted for API compatibility but is not used directly.
+    """
+
+    return await refinement_loop(
+        program_factory,
+        llm,
+        prompt_helper,
+        base_refine_template,
+        response,
+        query_str,
+        text_chunk,
+        streaming,
+        verbose,
+        True,
+        **response_kwargs,
+    )


### PR DESCRIPTION
## Summary
- Add project scope and integration roadmap document
- Link new roadmap from README for discoverability
- Refactor refinement to use helper program loops for synchronous and async flows

## Testing
- `pip install --no-deps -e .`
- `agent --help`
- `python -m py_compile libs/llamaindex/llama-index-core/llama_index/core/base/response/schema.py libs/llamaindex/llama-index-core/llama_index/core/response_synthesizers/refine.py`

------
https://chatgpt.com/codex/tasks/task_e_689e4213c1388325b891099a0c9b25f1