### PR TITLE
Add planning and sandbox tests

### DIFF
--- a/core/tests/test_planning.py
+++ b/core/tests/test_planning.py
@@ -1,0 +1,51 @@
+import importlib
+
+from core.agentControl import plan_steps
+import core.planning.advanced as adv
+
+
+def test_plan_steps_rule_based(monkeypatch):
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    steps = plan_steps("Visit http://example.com and read report.pdf")
+    assert steps == [
+        {"tool": "web_fetch", "args": {"url": "https://example.com"}},
+        {"tool": "pdf_text", "args": {"path": "./document.pdf"}},
+    ]
+
+
+def test_expand_plan_behaviors(monkeypatch):
+    monkeypatch.setenv("ADVANCED_PLANNING", "false")
+    importlib.reload(adv)
+    raw = [{"tool": "web_fetch", "args": {"url": "https://example.com"}}]
+    assert adv.expand_plan(raw) == raw
+
+    monkeypatch.setenv("ADVANCED_PLANNING", "true")
+    importlib.reload(adv)
+    plan = [
+        {
+            "if": False,
+            "then": [{"tool": "web_fetch", "args": {"url": "1"}}],
+            "else": [{"tool": "web_fetch", "args": {"url": "2"}}],
+        },
+        {
+            "loop": {"times": 2},
+            "steps": [{"tool": "pdf_text", "args": {"path": "./document.pdf"}}],
+        },
+        {
+            "retry": {"max": 2},
+            "steps": [{"tool": "sample_echo", "args": {"text": "hi"}}],
+        },
+        {
+            "while": {"cond": True, "max": 1},
+            "steps": [{"tool": "sample_echo", "args": {"text": "x"}}],
+        },
+    ]
+    expanded = adv.expand_plan(plan)
+    assert [s["tool"] for s in expanded] == [
+        "web_fetch",
+        "pdf_text",
+        "pdf_text",
+        "sample_echo",
+        "sample_echo",
+        "sample_echo",
+    ]

--- a/core/tests/test_registry_policy_planning.py
+++ b/core/tests/test_registry_policy_planning.py
@@ -1,9 +1,13 @@
 import importlib
 from types import SimpleNamespace
+
+import pytest
+
 from core.tools.registry import discover, _REGISTRY
 import core.planning.advanced as adv
 from core.security.policy import check_tool_allowed
 from core.agentControl import execute_steps
+import core.security.policy as policy
 
 
 def test_registry_discovers_plugins():
@@ -84,3 +88,25 @@ def test_duplicate_registration_warning():
         register(spec2)
         assert any("duplicate tool registration" in str(wi.message) for wi in w)
 
+
+def test_allowed_tools(monkeypatch):
+    monkeypatch.setenv("POLICY_ENGINE_ENABLED", "true")
+    monkeypatch.setenv("ALLOWED_TOOLS", "json_parse")
+    check_tool_allowed("json_parse", {})
+    with pytest.raises(PermissionError):
+        check_tool_allowed("web_fetch", {"url": "https://example.com"})
+
+
+def test_risky_tool_uses_sandbox(monkeypatch):
+    monkeypatch.setenv("HITL_DEFAULT", "false")
+    monkeypatch.setattr(policy, "RISKY_TOOLS", {"json_parse"})
+    called = {}
+
+    def _sandbox(fn, args, timeout_s=20):
+        called["sandbox"] = True
+        return fn(args)
+
+    monkeypatch.setattr("core.agentControl.run_in_sandbox", _sandbox)
+    out = execute_steps("echo", steps=[{"tool": "json_parse", "args": {"text": "{}"}}])
+    assert called.get("sandbox") is True
+    assert out["outputs"][0]["output"]["json"] == {}


### PR DESCRIPTION
## Summary
- cover rule-based planner and advanced plan expansion
- verify tool allow-list enforcement and sandbox execution for risky plugins

## Testing
- `python -m py_compile core/tests/test_planning.py core/tests/test_registry_policy_planning.py`
- `PYTHONPATH=. pytest core/tests/test_planning.py core/tests/test_registry_policy_planning.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1b6cb7c288325b003c688eebf8ddc