### PR TITLE
Add agent entrypoint and policy-enforced builtin tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ graph TD
 pip install --no-deps -e .
 ```
 
+### Run an instruction
+
+```bash
+python -m agent_mono.cli "list files in /tmp"
+```
+
 ### Create a plugin
 
 ```bash

--- a/agent_mono/__init__.py
+++ b/agent_mono/__init__.py
@@ -1,0 +1,1 @@
+"""Core package for agent runtime."""

--- a/agent_mono/cli.py
+++ b/agent_mono/cli.py
@@ -1,0 +1,22 @@
+"""Simple CLI entrypoint for the agent runtime."""
+from __future__ import annotations
+
+import argparse
+
+
+def start_execution_plan(instruction: str) -> None:
+    """Internal stub for starting an execution plan."""
+    print(instruction)
+
+
+def run_agent(instruction: str) -> None:
+    """Normalize the instruction and start execution."""
+    normalized = instruction.strip()
+    start_execution_plan(normalized)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run a single instruction")
+    parser.add_argument("instruction", type=str, help="Instruction for the agent")
+    args = parser.parse_args()
+    run_agent(args.instruction)

--- a/agent_mono/fs_utils.py
+++ b/agent_mono/fs_utils.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import os, tempfile
+
+
+def write_text_atomic(path: Path, content: str, encoding: str = "utf-8") -> None:
+    d = path.parent
+    d.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", delete=False, dir=str(d), encoding=encoding) as f:
+        tmp = Path(f.name)
+        f.write(content)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)

--- a/agent_mono/http_utils.py
+++ b/agent_mono/http_utils.py
@@ -1,0 +1,13 @@
+from urllib.request import Request, urlopen
+
+
+def fetch_text(url: str, timeout: float = 10.0, max_bytes: int = 1_000_000) -> str:
+    req = Request(url, headers={"User-Agent": "agent-mono"})
+    with urlopen(req, timeout=timeout) as resp:
+        ct = resp.headers.get("Content-Type", "")
+        data = resp.read(max_bytes + 1)
+        if len(data) > max_bytes:
+            raise ValueError("response too large")
+        if "text" not in ct and "json" not in ct:
+            raise ValueError(f"unexpected content-type {ct!r}")
+        return data.decode("utf-8", errors="strict")

--- a/agent_mono/models.py
+++ b/agent_mono/models.py
@@ -1,0 +1,21 @@
+"""Pydantic models for agent runtime."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class TaskSpec(BaseModel):
+    goal: str
+    constraints: List[str] = Field(default_factory=list)
+    allowed_paths: List[Path] = Field(default_factory=list)
+    forbidden_paths: List[Path] = Field(default_factory=list)
+    success_criteria: List[str] = Field(default_factory=list)
+    risk_level: int = 0
+    plan: Optional[Dict] = None
+    artifacts: Optional[Dict] = None
+
+    def to_json(self) -> str:
+        return self.model_dump_json()

--- a/agent_mono/policy.py
+++ b/agent_mono/policy.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import json, threading, time
+from pathlib import Path
+from typing import Dict, Literal
+
+_POLICY = {"capabilities": {}}  # type: Dict[str, Dict[str, Literal["allow","deny"]]]
+_LOCK = threading.RLock()
+_MTIME = 0.0
+_PATH = Path(__file__).resolve().parents[1] / "policies.json"
+
+class PolicyError(RuntimeError):
+    pass
+
+def _reload_if_needed() -> None:
+    global _MTIME
+    try:
+        mtime = _PATH.stat().st_mtime
+    except FileNotFoundError:
+        raise PolicyError("policies.json not found")
+    if mtime <= _MTIME:
+        return
+    data = json.loads(_PATH.read_text(encoding="utf-8"))
+    caps = data.get("capabilities", {})
+    if not isinstance(caps, dict):
+        raise PolicyError("invalid policy format")
+    for k, v in caps.items():
+        if v.get("default") not in ("allow", "deny"):
+            raise PolicyError(f"invalid default for {k}")
+    _POLICY.clear()
+    _POLICY.update({"capabilities": caps})
+    _MTIME = mtime
+
+def check(capability: str) -> None:
+    with _LOCK:
+        _reload_if_needed()
+        action = _POLICY["capabilities"].get(capability, {}).get("default", "allow")
+        if action == "deny":
+            raise PermissionError(f"{capability} denied")

--- a/agent_mono/shell_utils.py
+++ b/agent_mono/shell_utils.py
@@ -1,0 +1,11 @@
+import subprocess
+
+
+def run_shell(argv: list[str], timeout: float = 10.0):
+    proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    return {
+        "success": proc.returncode == 0,
+        "code": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+    }

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,2 @@
+"""Configuration defaults for agent runtime."""
+POLICY_ENGINE_ENABLED = True

--- a/core/tests/test_policy_default_deny.py
+++ b/core/tests/test_policy_default_deny.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import pytest
+
+from tools.builtin.fs import fs_write_text
+
+
+def test_fs_write_denied(tmp_path):
+    target = tmp_path / "x.txt"
+    with pytest.raises(PermissionError):
+        fs_write_text(target, "hi")

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,6 +10,12 @@ pip install --no-deps -e .
 
 Any Python package manager can be used. The project targets Python 3.10+.
 
+## Running an instruction
+
+```bash
+python -m agent_mono.cli "list files in /tmp"
+```
+
 ## Creating a plugin
 
 ```bash

--- a/policies.json
+++ b/policies.json
@@ -1,4 +1,9 @@
 {
+  "capabilities": {
+    "fs.write": {"default": "deny"},
+    "subprocess": {"default": "deny"},
+    "network": {"default": "deny"}
+  },
   "rag": {
     "scopes": [
       "mail.send",

--- a/tools/builtin/__init__.py
+++ b/tools/builtin/__init__.py
@@ -1,0 +1,1 @@
+"""Builtin tool implementations."""

--- a/tools/builtin/fs.py
+++ b/tools/builtin/fs.py
@@ -1,0 +1,32 @@
+"""Filesystem write utility."""
+from __future__ import annotations
+
+import sys
+import difflib
+from pathlib import Path
+from typing import Dict
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from config import POLICY_ENGINE_ENABLED
+from agent_mono import policy
+from agent_mono.fs_utils import write_text_atomic
+
+
+def _check_policy(capability: str) -> None:
+    if not POLICY_ENGINE_ENABLED:
+        return
+    policy.check(capability)
+
+
+def fs_write_text(path: Path, content: str) -> Dict:
+    """Write text to a file after policy check."""
+    _check_policy("fs.write")
+    original = path.read_text() if path.exists() else ""
+    write_text_atomic(path, content)
+    diff = "\n".join(
+        difflib.unified_diff(original.splitlines(), content.splitlines(), lineterm="")
+    )
+    return {"success": True, "diff": diff}

--- a/tools/builtin/fs_read.py
+++ b/tools/builtin/fs_read.py
@@ -1,0 +1,25 @@
+"""Filesystem read utility."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Dict
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from config import POLICY_ENGINE_ENABLED
+from agent_mono import policy
+
+
+def _check_policy(capability: str) -> None:
+    if not POLICY_ENGINE_ENABLED:
+        return
+    policy.check(capability)
+
+
+def fs_read(path: Path) -> Dict:
+    """Read text from a file after policy check."""
+    _check_policy("fs.read")
+    return {"success": True, "content": path.read_text()}

--- a/tools/builtin/http.py
+++ b/tools/builtin/http.py
@@ -1,0 +1,27 @@
+"""HTTP fetch utility."""
+from __future__ import annotations
+
+import sys
+from typing import Dict
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from config import POLICY_ENGINE_ENABLED
+from agent_mono import policy
+from agent_mono.http_utils import fetch_text
+
+
+def _check_policy(capability: str) -> None:
+    if not POLICY_ENGINE_ENABLED:
+        return
+    policy.check(capability)
+
+
+def http_fetch_text(url: str) -> Dict:
+    """Fetch text from a URL after policy check."""
+    _check_policy("network")
+    text = fetch_text(url)
+    return {"success": True, "text": text}

--- a/tools/builtin/shell.py
+++ b/tools/builtin/shell.py
@@ -1,0 +1,26 @@
+"""Shell execution utility."""
+from __future__ import annotations
+
+import sys
+from typing import Dict, List
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from config import POLICY_ENGINE_ENABLED
+from agent_mono import policy
+from agent_mono.shell_utils import run_shell
+
+
+def _check_policy(capability: str) -> None:
+    if not POLICY_ENGINE_ENABLED:
+        return
+    policy.check(capability)
+
+
+def shell_run_sandboxed(argv: List[str]) -> Dict:
+    """Execute a shell command with policy enforcement."""
+    _check_policy("subprocess")
+    return run_shell(argv)


### PR DESCRIPTION
## Summary
- add `run_agent` CLI for executing a single instruction
- define `TaskSpec` pydantic model and enable default policy engine
- implement policy-aware builtin tools and deny risky capabilities by default
- add policy loader and safe helper utilities for filesystem, HTTP, and shell operations

## Testing
- `pip install --no-deps -e .`
- `agent --help`
- `python -m agent_mono.cli "list files in /tmp"`
- `python -m py_compile agent_mono/policy.py agent_mono/fs_utils.py agent_mono/http_utils.py agent_mono/shell_utils.py tools/builtin/fs.py tools/builtin/fs_read.py tools/builtin/http.py tools/builtin/shell.py`
- `pytest core/tests/test_policy_default_deny.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a45fd45b10832584821c0ebbb2e3fa