### PR TITLE
Refactor plugin loading and optional deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ graph TD
 ### Installation
 
 ```bash
-pip install --no-deps -e .
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+```
+
+Install optional extras only when needed:
+
+```bash
+pip install -e ".[http,images]"
 ```
 
 ### Create a plugin

--- a/agent_mono/__init__.py
+++ b/agent_mono/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for agent-mono runtime."""

--- a/agent_mono/plugins.py
+++ b/agent_mono/plugins.py
@@ -1,0 +1,26 @@
+"""Entry-point based plugin loader with lazy imports."""
+from importlib.metadata import entry_points, EntryPoint
+from typing import Dict, Any, Mapping
+
+GROUP = "agent_mono.plugins"
+
+def list_plugins() -> Mapping[str, EntryPoint]:
+    """Return a mapping of plugin names to their entry points."""
+    return {ep.name: ep for ep in entry_points(group=GROUP)}
+
+def load_plugin(name: str) -> Any:
+    """Load a plugin object by name without importing others."""
+    plugins = list_plugins()
+    if name not in plugins:
+        raise KeyError(f"unknown plugin {name!r}")
+    ep = plugins[name]
+    return ep.load()
+
+def run_plugin(name: str, **kw: Any) -> Any:
+    """Load the named plugin and execute it with provided keywords."""
+    plugin = load_plugin(name)
+    if not hasattr(plugin, "run"):
+        raise TypeError(f"plugin {name!r} does not expose a run callable")
+    return plugin.run(**kw)  # type: ignore[no-any-return]
+
+__all__ = ["GROUP", "list_plugins", "load_plugin", "run_plugin"]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,14 @@ This guide shows how to try the experimental agent runtime. For an overview of t
 ## Installation
 
 ```bash
-pip install --no-deps -e .
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+```
+
+Include extras to enable plugin dependencies:
+
+```bash
+pip install -e ".[http,images]"
 ```
 
 Any Python package manager can be used. The project targets Python 3.10+.

--- a/plugins/image_info.py
+++ b/plugins/image_info.py
@@ -1,18 +1,19 @@
 from core.instrumentation import instrument_tool
 from core.tools.registry import ToolSpec
 
-try:
-	from PIL import Image  # type: ignore
-except Exception:
-	Image = None  # type: ignore
-
 
 @instrument_tool("image_info")
 def _run(args):
-	path = args.get("path")
-	if not path or Image is None:
-		return {"width": 0, "height": 0}
-	im = Image.open(path)
-	return {"width": im.width, "height": im.height}
+    path = args.get("path")
+    if not path:
+        return {"width": 0, "height": 0}
+    try:
+        from PIL import Image  # type: ignore
+    except ImportError as e:  # pragma: no cover
+        raise RuntimeError("pillow extra is not installed; install with `.[images]`") from e
+    with Image.open(path) as im:
+        return {"width": im.width, "height": im.height}
+
 
 spec = ToolSpec(name="image_info", input_model=None, run=_run)
+

--- a/plugins/web_fetch.py
+++ b/plugins/web_fetch.py
@@ -1,25 +1,28 @@
-import json
-try:
-	import requests
-except Exception:
-	requests = None  # type: ignore
 from core.tools.registry import ToolSpec
 from core.instrumentation import instrument_tool
+from urllib.parse import urlsplit
 
 
 @instrument_tool("web_fetch")
 def _run(args):
-	url = args.get("url")
-	if not url:
-		raise ValueError("missing url")
-	if requests is None:
-		import urllib.request
-		with urllib.request.urlopen(url, timeout=15) as r:  # type: ignore
-			data = r.read()
-			text = data.decode("utf-8", errors="ignore")
-			return {"text": text[:10000]}
-	r = requests.get(url, timeout=15)
-	r.raise_for_status()
-	return {"text": r.text[:10000]}
+    url = args.get("url")
+    if not url:
+        raise ValueError("missing url")
+    parts = urlsplit(url)
+    if parts.scheme not in {"http", "https"}:
+        raise ValueError("unsupported URL scheme")
+    try:
+        import httpx  # type: ignore
+    except ImportError as e:  # pragma: no cover
+        raise RuntimeError("httpx extra is not installed; install with `.[http]`") from e
+    # Tight but reasonable defaults; total read cap to 10000 chars
+    timeout = httpx.Timeout(connect=5.0, read=5.0, write=5.0, pool=5.0)
+    headers = {"User-Agent": "agent-mono/0.1 (+github.com/wjabrac/agent-mono)"}
+    with httpx.Client(timeout=timeout, headers=headers, http2=False) as client:
+        r = client.get(url, follow_redirects=True)
+        r.raise_for_status()
+        return {"text": r.text[:10000]}
+
 
 spec = ToolSpec(name="web_fetch", input_model=None, run=_run)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,26 @@ version = "0.1.0"
 description = "Experimental agent runtime monorepo"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = ["pydantic>=2"]
 
 [project.scripts]
 agent = "tools.agent_cli:main"
 
+[project.optional-dependencies]
+http = ["httpx>=0.27"]
+shell = ["psutil>=5.9"]
+images = ["pillow>=10"]
+
+[project.entry-points."agent_mono.plugins"]
+csv_parse = "plugins.csv_parse:spec"
+json_parse = "plugins.json_parse:spec"
+pdf_text = "plugins.pdf_text:spec"
+image_info = "plugins.image_info:spec"
+web_fetch = "plugins.web_fetch:spec"
+introspect = "plugins.introspect:spec"
+agent_suggest_refactor = "plugins.agent_suggest:spec_refactor"
+agent_suggest_create = "plugins.agent_suggest:spec_create"
+
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["core*", "tools*"]
+include = ["core*", "tools*", "agent_mono*", "plugins*"]


### PR DESCRIPTION
## Summary
- harden runtime extras for image and web plugins
- add plugin packaging and loader validation
- refresh install docs for venv and extras

## Testing
- `pip install --no-deps -e .`
- `agent --help`
- `python -m py_compile agent_mono/plugins.py plugins/image_info.py plugins/web_fetch.py`


------
https://chatgpt.com/codex/tasks/task_e_68a46535f9e08325b2a9f81b79e243cb