### PR TITLE
Agent cleanup: markdown_browser + sandbox + tests

### DIFF
--- a/apps/autoagent-core/autoagent/environment/markdown_browser/mdconvert.py
+++ b/apps/autoagent-core/autoagent/environment/markdown_browser/mdconvert.py
@@ -18,7 +18,14 @@ import mammoth
 import markdownify
 import pandas as pd
 import pptx
-import pdfminer.high_level
+
+try:
+    import pdfminer.high_level
+
+    IS_PDFMINER_AVAILABLE = True
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    pdfminer = None  # type: ignore[assignment]
+    IS_PDFMINER_AVAILABLE = False
 
 try:
     from docling.document_converter import DocumentConverter as DocLingDocumentConverter
@@ -507,8 +514,12 @@ class PdfConverter(DocumentConverter):
             converter = DocLingDocumentConverter()
             result = converter.convert(local_path)
             text_content = result.document.export_to_markdown()
-        else:
+        elif IS_PDFMINER_AVAILABLE:
             text_content = pdfminer.high_level.extract_text(local_path)
+        else:  # pragma: no cover - defensive
+            raise UnsupportedFormatException(
+                "Could not convert PDF: missing docling and pdfminer"
+            )
 
         return DocumentConverterResult(
             title=None,
@@ -1142,7 +1153,7 @@ class MarkdownConverter:
     def _append_ext(self, extensions, ext):
         if ext is None:
             return
-        ext = ext.strip()
+        ext = ext.strip().lower()
         if ext == "":
             return
         if ext not in extensions:

--- a/apps/autoagent-core/autoagent/environment/markdown_browser/requests_markdown_browser.py
+++ b/apps/autoagent-core/autoagent/environment/markdown_browser/requests_markdown_browser.py
@@ -57,13 +57,15 @@ class RequestsMarkdownBrowser(AbstractMarkdownBrowser):
         Instantiate a new RequestsMarkdownBrowser.
 
         Arguments:
+            local_root: Root directory where browser data is stored locally.
+            workplace_name: Name of the workspace directory within ``local_root``.
             start_page: The page on which the browser starts (default: "about:blank")
             viewport_size: Approximately how many *characters* fit in the viewport. Viewport dimensions are adjusted dynamically to avoid cutting off words (default: 8192).
             downloads_folder: Path to where downloads are saved. If None, downloads are disabled. (default: None)
             search_engine: An instance of MarkdownSearch, which handles web searches performed by this browser (default: a new `BingMarkdownSearch()` with default parameters)
-            markdown_converted: An instance of a MarkdownConverter used to convert HTML pages and downloads to Markdown (default: a new `MarkdownConerter()` with default parameters)
-            request_session: The session from which to issue requests (default: a new `requests.Session()` instance with default parameters)
-            request_get_kwargs: Extra parameters passed to evert `.get()` call made to requests.
+            markdown_converter: An instance of a MarkdownConverter used to convert HTML pages and downloads to Markdown (default: a new `MarkdownConverter()` with default parameters)
+            requests_session: The session from which to issue requests (default: a new `requests.Session()` instance with default parameters)
+            requests_get_kwargs: Extra parameters passed to every `.get()` call made to requests.
         """
         self.local_workplace = os.path.join(local_root, workplace_name)
         self.docker_workplace = f"/{workplace_name}"
@@ -340,7 +342,7 @@ class RequestsMarkdownBrowser(AbstractMarkdownBrowser):
         Arguments:
             url: The fully-qualified URL to fetch.
             session: Used to override the session used for this request. If None, use `self._requests_session` as usual.
-            requests_get_kwargs: Extra arguments passes to `requests.Session.get`.
+            requests_get_kwargs: Extra arguments passed to `requests.Session.get`.
         """
         download_path: str = ""
         response: Union[requests.Response, None] = None

--- a/apps/autoagent-core/autoagent/tests/test_markdown_browser.py
+++ b/apps/autoagent-core/autoagent/tests/test_markdown_browser.py
@@ -26,5 +26,5 @@ def test_append_ext_deduplicates():
     converter = MarkdownConverter()
     exts = []
     converter._append_ext(exts, ".txt")
-    converter._append_ext(exts, ".txt")
+    converter._append_ext(exts, ".TXT")
     assert exts == [".txt"]

--- a/plugins/sandbox.py
+++ b/plugins/sandbox.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from core.security.sandbox import SandboxTimeout, run_in_sandbox
 
 __all__ = ["run_in_sandbox", "SandboxTimeout"]


### PR DESCRIPTION
## Summary
- streamline sandbox plugin to re-export run_in_sandbox and SandboxTimeout
- improve PDF conversion with optional DocLing and pdfminer fallback
- fix markdown browser docstrings and extension de-dup logic
- ensure extension dedup is case-insensitive
- document workspace parameters in RequestsMarkdownBrowser constructor

## Testing
- `ruff check apps/autoagent-core/autoagent/environment/markdown_browser/mdconvert.py apps/autoagent-core/autoagent/environment/markdown_browser/requests_markdown_browser.py apps/autoagent-core/autoagent/tests/test_markdown_browser.py core/tests/test_sandbox.py plugins/sandbox.py --fix`
- `black apps/autoagent-core/autoagent/environment/markdown_browser/mdconvert.py apps/autoagent-core/autoagent/environment/markdown_browser/requests_markdown_browser.py apps/autoagent-core/autoagent/tests/test_markdown_browser.py core/tests/test_sandbox.py plugins/sandbox.py`
- `python -m py_compile apps/autoagent-core/autoagent/environment/markdown_browser/mdconvert.py apps/autoagent-core/autoagent/environment/markdown_browser/requests_markdown_browser.py apps/autoagent-core/autoagent/tests/test_markdown_browser.py core/tests/test_sandbox.py plugins/sandbox.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers', among others)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d9c0c0b08325a043b33b11467361