### PR TITLE
Implement planning runtime in CLI with policy checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,17 @@ For optional network and image plugins install extras:
 ```bash
 pip install --no-deps -e .[http,images]
 ```
+Install OpenTelemetry packages to enable metrics and tracing:
+```bash
+pip install opentelemetry-api opentelemetry-sdk
+```
 ### Run an instruction
 ```bash
 python -m agent_mono.cli "list files in /tmp"
 ```
+The CLI now discovers plugins, generates a plan, and executes it with policy
+checks before each phase. Metrics for discovery, planning, and execution are
+recorded to the local trace store for diagnostics.
 
 ### Create a plugin
 

--- a/agent_mono/cli.py
+++ b/agent_mono/cli.py
@@ -2,11 +2,58 @@
 from __future__ import annotations
 
 import argparse
+import json
+
+import time
+
+from core.tools import registry
+from core.agentControl import execute_steps, plan_steps
+from core.observability.trace import start_trace, log_event
+from core.trace_context import set_trace
+
+from . import policy
 
 
 def start_execution_plan(instruction: str) -> None:
-    """Internal stub for starting an execution plan."""
-    print(instruction)
+    """Load tools, plan steps, and execute the plan."""
+    trace_id = start_trace()
+    set_trace(None, trace_id, [])
+
+    policy.check("plugins.load")
+    t0 = time.time()
+    registry.discover("plugins")
+    discover_ms = int((time.time() - t0) * 1000)
+    try:
+        log_event(trace_id, "runtime", "discover", {"ms": discover_ms, "tools": registry.names()})
+    except Exception:
+        pass
+
+    policy.check("plan.generate")
+    t1 = time.time()
+    plan = plan_steps(instruction)
+    plan_ms = int((time.time() - t1) * 1000)
+    try:
+        log_event(trace_id, "runtime", "plan", {"ms": plan_ms, "steps": plan})
+    except Exception:
+        pass
+    available = set(registry.names())
+    missing = [step for step in plan if step.get("tool") not in available]
+    plan = [step for step in plan if step.get("tool") in available]
+    if missing:
+        try:
+            log_event(trace_id, "runtime", "plan_filtered", {"missing": missing})
+        except Exception:
+            pass
+
+    policy.check("plan.execute")
+    t2 = time.time()
+    result = execute_steps(instruction, steps=plan, trace_id=trace_id)
+    exec_ms = int((time.time() - t2) * 1000)
+    try:
+        log_event(trace_id, "runtime", "execute", {"ms": exec_ms})
+    except Exception:
+        pass
+    print(json.dumps(result, indent=2))
 
 
 def run_agent(instruction: str) -> None:

--- a/core/agentControl.py
+++ b/core/agentControl.py
@@ -304,14 +304,15 @@ def execute_steps(
     steps: List[Dict[str, Any]] | None = None,
     thread_id=None,
     tags=None,
+    trace_id: str | None = None,
 ) -> Dict[str, Any]:
     """Plan, schedule, and execute tool steps for a prompt."""
-    trace_id = start_trace(thread_id)
+    trace_id = trace_id or start_trace(thread_id)
     _thread_local.trace_id = trace_id
     set_trace(thread_id, trace_id, tags or [])
     out = []
     # Plan if not provided
-    if not steps:
+    if steps is None:
         planned = plan_steps(prompt)
         planned = expand_plan(planned)
         log_event(trace_id, "decision", "planner:proposed", {"steps": planned})

--- a/core/tools/registry.py
+++ b/core/tools/registry.py
@@ -7,7 +7,7 @@ import inspect
 import os
 import pkgutil
 import warnings
-from typing import Dict, Any, Callable, Type, Optional
+from typing import Dict, Any, Callable, Type, Optional, List
 
 from pydantic import BaseModel
 
@@ -70,6 +70,12 @@ class _RegistryWrapper:
 
 if _metrics is not None:
     _metrics.registry = _RegistryWrapper()
+
+
+def names() -> List[str]:
+    """Return names of all registered tools."""
+
+    return list(_REGISTRY.keys())
 
 
 def register(tool: ToolSpec) -> None:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,6 +17,11 @@ pip install --no-deps -e .[http,images]
 The `[http]` extra installs `httpx` for network tools and `[images]` installs
 `Pillow` for image utilities.
 
+Install OpenTelemetry libraries to capture metrics and traces:
+```bash
+pip install opentelemetry-api opentelemetry-sdk
+```
+
 Any Python package manager can be used. The project targets Python 3.10+.
 
 ## Running an instruction
@@ -24,6 +29,9 @@ Any Python package manager can be used. The project targets Python 3.10+.
 ```bash
 python -m agent_mono.cli "list files in /tmp"
 ```
+The command discovers available plugins, plans the steps, and executes the plan
+with policy checks between discovery, planning, and execution. Metrics for each
+phase are written to the local trace database for troubleshooting.
 
 ## Creating a plugin
 


### PR DESCRIPTION
## Summary
- Trace plugin discovery, planning, and execution phases in the CLI and filter plans to available tools
- Allow `execute_steps` to accept an optional `trace_id` and only auto-plan when steps are omitted
- Document OpenTelemetry requirement for metrics and tracing in README and quickstart
- Expose tool registry names and log any plan steps dropped due to missing tools

## Testing
- `pip install opentelemetry-api opentelemetry-sdk`
- `pip install --no-deps -e .`
- `agent --help`
- `python -m py_compile agent_mono/cli.py core/tools/registry.py`
- `python -m agent_mono.cli "test"`


------
https://chatgpt.com/codex/tasks/task_e_68a8ee6551fc832591d6c3a90cbbb0fe