### PR TITLE
Harden voice assistant resiliency and persona controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,36 @@ a warning is printed and the tool executes without isolation.
 
 See [docs/quickstart.md](docs/quickstart.md) for more examples.
 
+### Natural language decomposition and voice chat
+
+Enable `ADVANCED_PLANNING` (and optionally `ENABLE_REFLECTION`) to let the
+runtime break a free-form instruction into a multi-step plan and checkpoints.
+For hands-free usage, the repo now includes a voice loop:
+
+```bash
+VOICE_STT_COMMAND="whisper.cpp -f {file} -otxt --print-colors false" \
+VOICE_TTS_COMMAND="espeak -w /tmp/agent_reply.wav '{text}' && play /tmp/agent_reply.wav" \
+VOICE_RECORD_COMMAND="ffmpeg -hide_banner -loglevel error -f alsa -i default -t 6 -ac 1 -ar 16000 {file}" \
+npm run voice
+```
+
+- `VOICE_STT_COMMAND` (required) should output the transcription to stdout and
+  must include the `{file}` placeholder for the recorded WAV file path.
+- `VOICE_TTS_COMMAND` (optional) should speak the `{text}` placeholder for the
+  agent reply; if unset the response is printed only.
+- `VOICE_RECORD_COMMAND` controls how audio is captured; the default expects
+  `ffmpeg` with an ALSA device. Override it for macOS (e.g.,
+  `ffmpeg -f avfoundation -i ":0" ...`) or other inputs. Adjust the duration
+  with `VOICE_RECORD_SECONDS`. Set `VOICE_COMMAND_TIMEOUT_MS` to avoid hanging
+  capture or playback commands.
+- `AGENT_PERSONA` and `AGENT_RESPONSE_TEMPERATURE` tune the reply style; the
+  default persona is "resilient, creative, and highly effective" while keeping
+  responses factual.
+
+Press Enter to capture an utterance, or type text directly. See the
+[quickstart](docs/quickstart.md#natural-language-decomposition-and-reflection)
+for more examples.
+
 ## Metrics stack
 
 Prometheus, Alertmanager, Grafana, and Jaeger services are included in

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -86,6 +86,57 @@ Risky tools run in a sandboxed subprocess on POSIX systems. On non-POSIX
 platforms tools are denied unless `ALLOW_UNSAFE_SANDBOX=1` is set, which prints
 a warning and executes the tool without isolation.
 
+## Natural language decomposition and reflection
+
+Turn on planning flags to let the runtime break down natural-language goals into
+multiple steps and optional checkpoints:
+
+```bash
+export ADVANCED_PLANNING=true         # expand loops/conditionals in plans
+export ENABLE_REFLECTION=true         # add self-reflection checkpoints
+export HITL_DEFAULT=false             # skip human approvals for unattended runs
+```
+
+Then run free-form tasks similar to Open Interpreter:
+
+```bash
+ADVANCED_PLANNING=true agent "Draft a 3-step plan to summarize ./docs and execute it"
+```
+
+The agent will emit a JSON trace containing the decomposed plan steps and
+results. Keep policy flags (`POLICY_ENGINE_ENABLED`, `ALLOWED_TOOLS`,
+`FS_SAFE_ROOTS`) tuned to the resources you intend to allow during execution.
+
+## Using voice as the front-end
+
+There is a built-in voice loop if you prefer a hands-free workflow. It records
+audio, sends it through a configurable STT command, runs the agent, and
+optionally speaks the reply:
+
+```bash
+VOICE_STT_COMMAND="whisper.cpp -f {file} -otxt --print-colors false" \
+VOICE_TTS_COMMAND="espeak -w /tmp/agent_reply.wav '{text}' && play /tmp/agent_reply.wav" \
+VOICE_RECORD_COMMAND="ffmpeg -hide_banner -loglevel error -f alsa -i default -t 6 -ac 1 -ar 16000 {file}" \
+npm run voice
+```
+
+- `VOICE_STT_COMMAND` is required and must print the transcription to stdout.
+  Use `{file}` to reference the recorded WAV file.
+- `VOICE_TTS_COMMAND` is optional and should speak the `{text}` placeholder for
+  the agent response.
+- `VOICE_RECORD_COMMAND` controls microphone capture; override it if your
+  environment needs a different `ffmpeg` input target. Set
+  `VOICE_RECORD_SECONDS` to adjust duration. Set `VOICE_COMMAND_TIMEOUT_MS` to
+  cap how long capture or playback commands can run.
+- Tune personality and creativity with `AGENT_PERSONA` and
+  `AGENT_RESPONSE_TEMPERATURE`; the default persona is "resilient, creative, and
+  highly effective" while staying grounded in facts.
+
+Press Enter to trigger recording or type directly into the prompt. The loop uses
+the same planning flags as the CLI, so you can combine `ADVANCED_PLANNING` and
+`ENABLE_REFLECTION` with the environment variables above to make it act more
+like an assistant.
+
 ## TypeScript agent
 
 Install dependencies and start the Node-based agent:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "dist/index.js",
   "scripts": {
-    "start": "ts-node src/index.ts"
+    "start": "ts-node src/index.ts",
+    "voice": "ts-node src/voice.ts"
   },
   "dependencies": {
     "@langchain/community": "^0.2.4",

--- a/src/ResponseGenerator.ts
+++ b/src/ResponseGenerator.ts
@@ -7,14 +7,21 @@ export class ResponseGenerator {
   private template: PromptTemplate;
 
   constructor() {
+    const persona =
+      process.env.AGENT_PERSONA ??
+      "You are a resilient, creative, and highly effective AI assistant who balances imagination with factual grounding.";
+    const temperature = Number(process.env.AGENT_RESPONSE_TEMPERATURE ?? "0.7");
+
     this.model = new Ollama({
       baseUrl: "http://localhost:11434",
       model: "llama2",
-      temperature: 0.7,
+      temperature,
     });
 
     this.template = PromptTemplate.fromTemplate(`
-You are an AI assistant. Generate a helpful response based on:
+${persona}
+
+Generate a helpful response based on:
 - User request: {input}
 - Context: {context}
 - Tool results: {results}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,7 @@
-import { Agent } from "./Agent";
-import { ToolRegistry } from "./Tools/ToolRegistry";
-import { WebSearchTool } from "./Tools/WebSearchTool";
-import { FileAnalysisTool } from "./Tools/FileAnalysisTool";
-import { CalculatorTool } from "./Tools/CalculatorTool";
-import { PersistentVectorMemory } from "./Memory/PersistentVectorMemory";
-import { Planner } from "./Planner";
-import { ResponseGenerator } from "./ResponseGenerator";
-import { DirectResponseTool } from "./Tools/DirectResponseTool";
 import readline from "readline";
+import { createDefaultAgent } from "./setupAgent";
 
-const toolRegistry = new ToolRegistry();
-toolRegistry.registerTool(new WebSearchTool());
-toolRegistry.registerTool(new FileAnalysisTool());
-toolRegistry.registerTool(new CalculatorTool());
-toolRegistry.registerTool(new DirectResponseTool());
-
-const memory = new PersistentVectorMemory();
-const planner = new Planner();
-const generator = new ResponseGenerator();
-
-const agent = new Agent(toolRegistry, memory, planner, generator);
+const { agent, memory } = createDefaultAgent();
 
 const rl = readline.createInterface({
   input: process.stdin,
@@ -31,27 +13,27 @@ async function main() {
 
   while (true) {
     const input = await new Promise<string>((resolve) =>
-      rl.question('\nUser: ', resolve)
+      rl.question("\nUser: ", resolve)
     );
 
-    if (input.toLowerCase() === 'exit') break;
+    if (input.toLowerCase() === "exit") break;
 
     try {
-      process.stdout.write('Agent: ');
+      process.stdout.write("Agent: ");
       const response = await agent.executeTask(input);
 
       for (const char of response) {
         process.stdout.write(char);
         await new Promise((resolve) => setTimeout(resolve, 20));
       }
-      process.stdout.write('\n');
+      process.stdout.write("\n");
     } catch (error) {
       console.error(`\nError: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
   rl.close();
-  console.log('Session ended');
+  console.log("Session ended");
 }
 
 memory.initialize().then(() => {

--- a/src/setupAgent.ts
+++ b/src/setupAgent.ts
@@ -1,0 +1,23 @@
+import { Agent } from "./Agent";
+import { ToolRegistry } from "./Tools/ToolRegistry";
+import { WebSearchTool } from "./Tools/WebSearchTool";
+import { FileAnalysisTool } from "./Tools/FileAnalysisTool";
+import { CalculatorTool } from "./Tools/CalculatorTool";
+import { PersistentVectorMemory } from "./Memory/PersistentVectorMemory";
+import { Planner } from "./Planner";
+import { ResponseGenerator } from "./ResponseGenerator";
+import { DirectResponseTool } from "./Tools/DirectResponseTool";
+
+export function createDefaultAgent(): { agent: Agent; memory: PersistentVectorMemory } {
+  const toolRegistry = new ToolRegistry();
+  toolRegistry.registerTool(new WebSearchTool());
+  toolRegistry.registerTool(new FileAnalysisTool());
+  toolRegistry.registerTool(new CalculatorTool());
+  toolRegistry.registerTool(new DirectResponseTool());
+
+  const memory = new PersistentVectorMemory();
+  const planner = new Planner();
+  const generator = new ResponseGenerator();
+
+  return { agent: new Agent(toolRegistry, memory, planner, generator), memory };
+}

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -1,0 +1,153 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import readline from "readline";
+import { exec as execCallback } from "child_process";
+import { promisify } from "util";
+import { createDefaultAgent } from "./setupAgent";
+
+const exec = promisify(execCallback);
+
+const recordSeconds = Number(process.env.VOICE_RECORD_SECONDS ?? "6");
+const recordCommandTemplate =
+  process.env.VOICE_RECORD_COMMAND ??
+  `ffmpeg -hide_banner -loglevel error -f alsa -i default -t ${recordSeconds} -ac 1 -ar 16000 {file}`;
+const sttCommandTemplate = process.env.VOICE_STT_COMMAND;
+const ttsCommandTemplate = process.env.VOICE_TTS_COMMAND;
+const commandTimeoutMs = Number(process.env.VOICE_COMMAND_TIMEOUT_MS ?? "20000");
+
+const { agent, memory } = createDefaultAgent();
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+function applyTemplate(template: string, values: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (_, key) => values[key] ?? "");
+}
+
+async function runCommand(command: string, description: string) {
+  try {
+    return await exec(command, { timeout: commandTimeoutMs });
+  } catch (error) {
+    const stderr = (error as { stderr?: string }).stderr ?? "";
+    const stdout = (error as { stdout?: string }).stdout ?? "";
+    const message = [description, stderr || stdout || (error as Error).message]
+      .filter(Boolean)
+      .join(": ");
+    throw new Error(message);
+  }
+}
+
+async function recordAudio(): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-voice-"));
+  const filePath = path.join(tmpDir, "input.wav");
+  const command = applyTemplate(recordCommandTemplate, { file: filePath });
+
+  await runCommand(command, "Recording failed");
+  return filePath;
+}
+
+async function transcribeAudio(filePath: string): Promise<string> {
+  if (!sttCommandTemplate) {
+    throw new Error(
+      "Set VOICE_STT_COMMAND to a command that prints the transcription (include {file} placeholder)."
+    );
+  }
+
+  if (!sttCommandTemplate.includes("{file}")) {
+    throw new Error("VOICE_STT_COMMAND must include {file} to point at the WAV recording");
+  }
+
+  const command = applyTemplate(sttCommandTemplate, { file: filePath });
+  const { stdout } = await runCommand(command, "Transcription failed");
+  return stdout.trim();
+}
+
+async function speak(text: string): Promise<void> {
+  if (!ttsCommandTemplate) return;
+
+  const command = applyTemplate(ttsCommandTemplate, { text });
+  try {
+    await runCommand(command, "Speech playback failed");
+  } catch (error) {
+    console.warn((error as Error).message);
+  }
+}
+
+async function captureUtterance(): Promise<string> {
+  const filePath = await recordAudio();
+  try {
+    return await transcribeAudio(filePath);
+  } finally {
+    await fs.rm(path.dirname(filePath), { recursive: true, force: true });
+  }
+}
+
+async function ask(prompt: string): Promise<string> {
+  return new Promise((resolve) => rl.question(prompt, resolve));
+}
+
+async function main() {
+  console.log(
+    'Voice assistant ready. Press Enter to speak, or type text. Type "exit" to quit.'
+  );
+
+  if (!sttCommandTemplate) {
+    console.warn("VOICE_STT_COMMAND is not set; speech capture will fail until configured.");
+  }
+
+  console.log(
+    `Config: record ${recordSeconds}s clips, command timeout ${commandTimeoutMs}ms${
+      ttsCommandTemplate ? "" : "; TTS disabled"
+    }.`
+  );
+
+  while (true) {
+    const userInput = await ask("\nYou (Enter to talk): ");
+
+    if (userInput.toLowerCase() === "exit") break;
+
+    let message = userInput.trim();
+
+    if (!message) {
+      try {
+        message = await captureUtterance();
+      } catch (error) {
+        console.error(
+          `Capture failed: ${error instanceof Error ? error.message : String(error)}. ` +
+            "Type instead to continue."
+        );
+        continue;
+      }
+    }
+
+    if (!message) {
+      console.log("No speech detected; try again.");
+      continue;
+    }
+
+    try {
+      console.log("Agent thinking...");
+      const response = await agent.executeTask(message);
+      console.log(`Agent: ${response}`);
+
+      await speak(response);
+    } catch (error) {
+      console.error(
+        `Agent error: ${error instanceof Error ? error.message : String(error)}. Continuing...`
+      );
+    }
+  }
+
+  rl.close();
+  console.log("Session ended");
+}
+
+memory.initialize().then(() => {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+});


### PR DESCRIPTION
## Summary
- allow the response generator persona and temperature to be tuned via environment
- harden the voice loop with command timeouts, validation, and clearer recovery paths
- document the new resilience and style controls in the README and quickstart

## Testing
- `printf 'exit\n' | npm run start --silent` *(fails: npm command unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69300a1532b48325a5715900969c8d56)