### PR TITLE
Harden env parsing and template handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,12 @@ npm run voice
 
 - `VOICE_STT_COMMAND` (required) should output the transcription to stdout and
   must include the `{file}` placeholder for the recorded WAV file path.
-- `VOICE_TTS_COMMAND` (optional) should speak the `{text}` placeholder for the
-  agent reply; the `{text}` substitution is shell-escaped for safety. If unset,
-  the response is printed only.
-- `VOICE_RECORD_COMMAND` controls how audio is captured; the default expects
-  `ffmpeg` with an ALSA device. Override it for macOS (e.g.,
+- `VOICE_TTS_COMMAND` (optional) must include the `{text}` placeholder for the
+  agent reply; the `{text}` substitution is shell-escaped before execution. If
+  unset, the response is printed only.
+- `VOICE_RECORD_COMMAND` controls how audio is captured and must include the
+  `{file}` placeholder; the default expects `ffmpeg` with an ALSA device.
+  Override it for macOS (e.g.,
   `ffmpeg -f avfoundation -i ":0" ...`) or other inputs. Adjust the duration
   with `VOICE_RECORD_SECONDS`. Set `VOICE_COMMAND_TIMEOUT_MS` to avoid hanging
   capture or playback commands.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ For hands-free usage, the repo now includes a voice loop:
 
 ```bash
 VOICE_STT_COMMAND="whisper.cpp -f {file} -otxt --print-colors false" \
-VOICE_TTS_COMMAND="espeak -w /tmp/agent_reply.wav '{text}' && play /tmp/agent_reply.wav" \
+VOICE_TTS_COMMAND='tmpfile=$(mktemp /tmp/agent_reply_XXXX.wav); espeak -w "$tmpfile" {text}; play "$tmpfile"; rm -f "$tmpfile"' \
 VOICE_RECORD_COMMAND="ffmpeg -hide_banner -loglevel error -f alsa -i default -t 6 -ac 1 -ar 16000 {file}" \
 npm run voice
 ```
@@ -117,7 +117,8 @@ npm run voice
 - `VOICE_STT_COMMAND` (required) should output the transcription to stdout and
   must include the `{file}` placeholder for the recorded WAV file path.
 - `VOICE_TTS_COMMAND` (optional) should speak the `{text}` placeholder for the
-  agent reply; if unset the response is printed only.
+  agent reply; the `{text}` substitution is shell-escaped for safety. If unset,
+  the response is printed only.
 - `VOICE_RECORD_COMMAND` controls how audio is captured; the default expects
   `ffmpeg` with an ALSA device. Override it for macOS (e.g.,
   `ffmpeg -f avfoundation -i ":0" ...`) or other inputs. Adjust the duration

--- a/README.md
+++ b/README.md
@@ -101,6 +101,57 @@ a warning is printed and the tool executes without isolation.
 
 See [docs/quickstart.md](docs/quickstart.md) for more examples.
 
+### Natural language decomposition and voice chat
+
+Enable `ADVANCED_PLANNING` (and optionally `ENABLE_REFLECTION`) to let the
+runtime break a free-form instruction into a multi-step plan and checkpoints.
+For hands-free usage, the repo now includes a voice loop:
+
+```bash
+VOICE_STT_COMMAND="whisper.cpp -f {file} -otxt --print-colors false" \
+VOICE_TTS_COMMAND="espeak -w /tmp/agent_reply.wav '{text}' && play /tmp/agent_reply.wav" \
+VOICE_RECORD_COMMAND="ffmpeg -hide_banner -loglevel error -f alsa -i default -t 6 -ac 1 -ar 16000 {file}" \
+npm run voice
+```
+
+- `VOICE_STT_COMMAND` (required) should output the transcription to stdout and
+  must include the `{file}` placeholder for the recorded WAV file path.
+- `VOICE_TTS_COMMAND` (optional) should speak the `{text}` placeholder for the
+  agent reply; if unset the response is printed only.
+- `VOICE_RECORD_COMMAND` controls how audio is captured; the default expects
+  `ffmpeg` with an ALSA device. Override it for macOS (e.g.,
+  `ffmpeg -f avfoundation -i ":0" ...`) or other inputs. Adjust the duration
+  with `VOICE_RECORD_SECONDS`. Set `VOICE_COMMAND_TIMEOUT_MS` to avoid hanging
+  capture or playback commands.
+- `AGENT_PERSONA` and `AGENT_RESPONSE_TEMPERATURE` tune the reply style; the
+  default persona is "resilient, creative, and highly effective" while keeping
+  responses factual.
+
+Press Enter to capture an utterance, or type text directly. See the
+[quickstart](docs/quickstart.md#natural-language-decomposition-and-reflection)
+for more examples.
+
+### Operation modes and approvals
+
+Control how autonomous the assistant can be by choosing an operation mode:
+
+- `AGENT_OPERATION_MODE=guided` (default): assume the agent has a clear mental
+  model; it will only pause for approval when a risky tool is selected or the
+  request includes destructive verbs (delete/remove/destroy/etc.).
+- `AGENT_OPERATION_MODE=exploratory`: treat the request as off-map; the agent
+  will present its plan and require confirmation unless
+  `AGENT_EXPLORATION_AUTO_APPROVE=true` is set.
+
+Tune the decision tree with:
+
+- `AGENT_APPROVAL_TOOLS="ToolA,ToolB"` to require approval when those tools are
+  in the plan.
+- `AGENT_APPROVAL_KEYWORDS="drop table,reset"` to add custom risky phrases
+  alongside the built-in destructive verbs.
+
+When approval is required, both the CLI and voice loop print the reasons and the
+planned steps, then ask for a `y/N` confirmation before proceeding.
+
 ## Metrics stack
 
 Prometheus, Alertmanager, Grafana, and Jaeger services are included in

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -122,12 +122,13 @@ npm run voice
 
 - `VOICE_STT_COMMAND` is required and must print the transcription to stdout.
   Use `{file}` to reference the recorded WAV file.
-- `VOICE_TTS_COMMAND` is optional and should speak the `{text}` placeholder for
+- `VOICE_TTS_COMMAND` is optional but must include the `{text}` placeholder for
   the agent response; the `{text}` substitution is shell-escaped for safety.
-- `VOICE_RECORD_COMMAND` controls microphone capture; override it if your
-  environment needs a different `ffmpeg` input target. Set
-  `VOICE_RECORD_SECONDS` to adjust duration. Set `VOICE_COMMAND_TIMEOUT_MS` to
-  cap how long capture or playback commands can run.
+- `VOICE_RECORD_COMMAND` controls microphone capture and must include the
+  `{file}` placeholder; override it if your environment needs a different
+  `ffmpeg` input target. Set `VOICE_RECORD_SECONDS` to adjust duration. Set
+  `VOICE_COMMAND_TIMEOUT_MS` to cap how long capture or playback commands can
+  run.
 - Tune personality and creativity with `AGENT_PERSONA` and
   `AGENT_RESPONSE_TEMPERATURE`; the default persona is "resilient, creative, and
   highly effective" while staying grounded in facts.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -115,7 +115,7 @@ optionally speaks the reply:
 
 ```bash
 VOICE_STT_COMMAND="whisper.cpp -f {file} -otxt --print-colors false" \
-VOICE_TTS_COMMAND="espeak -w /tmp/agent_reply.wav '{text}' && play /tmp/agent_reply.wav" \
+VOICE_TTS_COMMAND='tmpfile=$(mktemp /tmp/agent_reply_XXXX.wav); espeak -w "$tmpfile" {text}; play "$tmpfile"; rm -f "$tmpfile"' \
 VOICE_RECORD_COMMAND="ffmpeg -hide_banner -loglevel error -f alsa -i default -t 6 -ac 1 -ar 16000 {file}" \
 npm run voice
 ```
@@ -123,7 +123,7 @@ npm run voice
 - `VOICE_STT_COMMAND` is required and must print the transcription to stdout.
   Use `{file}` to reference the recorded WAV file.
 - `VOICE_TTS_COMMAND` is optional and should speak the `{text}` placeholder for
-  the agent response.
+  the agent response; the `{text}` substitution is shell-escaped for safety.
 - `VOICE_RECORD_COMMAND` controls microphone capture; override it if your
   environment needs a different `ffmpeg` input target. Set
   `VOICE_RECORD_SECONDS` to adjust duration. Set `VOICE_COMMAND_TIMEOUT_MS` to

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -86,6 +86,77 @@ Risky tools run in a sandboxed subprocess on POSIX systems. On non-POSIX
 platforms tools are denied unless `ALLOW_UNSAFE_SANDBOX=1` is set, which prints
 a warning and executes the tool without isolation.
 
+## Natural language decomposition and reflection
+
+Turn on planning flags to let the runtime break down natural-language goals into
+multiple steps and optional checkpoints:
+
+```bash
+export ADVANCED_PLANNING=true         # expand loops/conditionals in plans
+export ENABLE_REFLECTION=true         # add self-reflection checkpoints
+export HITL_DEFAULT=false             # skip human approvals for unattended runs
+```
+
+Then run free-form tasks similar to Open Interpreter:
+
+```bash
+ADVANCED_PLANNING=true agent "Draft a 3-step plan to summarize ./docs and execute it"
+```
+
+The agent will emit a JSON trace containing the decomposed plan steps and
+results. Keep policy flags (`POLICY_ENGINE_ENABLED`, `ALLOWED_TOOLS`,
+`FS_SAFE_ROOTS`) tuned to the resources you intend to allow during execution.
+
+## Using voice as the front-end
+
+There is a built-in voice loop if you prefer a hands-free workflow. It records
+audio, sends it through a configurable STT command, runs the agent, and
+optionally speaks the reply:
+
+```bash
+VOICE_STT_COMMAND="whisper.cpp -f {file} -otxt --print-colors false" \
+VOICE_TTS_COMMAND="espeak -w /tmp/agent_reply.wav '{text}' && play /tmp/agent_reply.wav" \
+VOICE_RECORD_COMMAND="ffmpeg -hide_banner -loglevel error -f alsa -i default -t 6 -ac 1 -ar 16000 {file}" \
+npm run voice
+```
+
+- `VOICE_STT_COMMAND` is required and must print the transcription to stdout.
+  Use `{file}` to reference the recorded WAV file.
+- `VOICE_TTS_COMMAND` is optional and should speak the `{text}` placeholder for
+  the agent response.
+- `VOICE_RECORD_COMMAND` controls microphone capture; override it if your
+  environment needs a different `ffmpeg` input target. Set
+  `VOICE_RECORD_SECONDS` to adjust duration. Set `VOICE_COMMAND_TIMEOUT_MS` to
+  cap how long capture or playback commands can run.
+- Tune personality and creativity with `AGENT_PERSONA` and
+  `AGENT_RESPONSE_TEMPERATURE`; the default persona is "resilient, creative, and
+  highly effective" while staying grounded in facts.
+
+Press Enter to trigger recording or type directly into the prompt. The loop uses
+the same planning flags as the CLI, so you can combine `ADVANCED_PLANNING` and
+`ENABLE_REFLECTION` with the environment variables above to make it act more
+like an assistant.
+
+### Operation modes and approvals
+
+Choose how assertive the assistant should be:
+
+- `AGENT_OPERATION_MODE=guided` (default) trusts the agent to act when it has a
+  clear plan but will pause for approval if destructive verbs are detected or if
+  a tool is explicitly gated.
+- `AGENT_OPERATION_MODE=exploratory` treats the request as off-map and requests
+  confirmation before running plans unless `AGENT_EXPLORATION_AUTO_APPROVE=true`
+  is set.
+
+Additional tuning knobs:
+
+- `AGENT_APPROVAL_TOOLS="ToolA,ToolB"` gates those tools behind approval.
+- `AGENT_APPROVAL_KEYWORDS="reset,drop table"` augments the built-in delete
+  verbs so you can catch domain-specific risky language.
+
+When a gate is hit, the CLI and voice loop show the proposed steps and ask for a
+`y/N` confirmation before proceeding.
+
 ## TypeScript agent
 
 Install dependencies and start the Node-based agent:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "dist/index.js",
   "scripts": {
-    "start": "ts-node src/index.ts"
+    "start": "ts-node src/index.ts",
+    "voice": "ts-node src/voice.ts"
   },
   "dependencies": {
     "@langchain/community": "^0.2.4",

--- a/src/Agent.ts
+++ b/src/Agent.ts
@@ -3,13 +3,17 @@ import { VectorMemory } from "./Memory/VectorMemory";
 import { Planner } from "./Planner";
 import { ResponseGenerator } from "./ResponseGenerator";
 import { Security } from "./security";
+import { PlanAssessment, assessPlan } from "./OperationMode";
+
+type ApprovalHandler = (assessment: PlanAssessment) => Promise<boolean>;
 
 export class Agent {
   constructor(
     private toolRegistry: ToolRegistry,
     private memory: VectorMemory,
     private planner: Planner,
-    private generator: ResponseGenerator
+    private generator: ResponseGenerator,
+    private requestApproval?: ApprovalHandler
   ) {}
 
   async executeTask(userInput: string): Promise<string> {
@@ -19,6 +23,24 @@ export class Agent {
       const context = await this.memory.retrieveRelevant(safeInput);
 
       const plan = await this.planner.generatePlan(safeInput, context);
+
+      const assessment = assessPlan(safeInput, plan);
+
+      if (assessment.requiresApproval) {
+        const approved = this.requestApproval
+          ? await this.requestApproval(assessment)
+          : false;
+
+        await this.memory.store(
+          `Approval ${approved ? "granted" : "denied"} for plan in ${assessment.mode} mode: ${
+            assessment.reasons
+          }`
+        );
+
+        if (!approved) {
+          return `Approval required (${assessment.reasons.join("; ")}). Plan aborted.`;
+        }
+      }
 
       const results: string[] = [];
       for (const step of plan.steps) {

--- a/src/OperationMode.ts
+++ b/src/OperationMode.ts
@@ -1,0 +1,81 @@
+import { Security } from "./security";
+
+type PlanStep = { tool: string; arguments: Record<string, unknown> };
+type Plan = { steps: PlanStep[] };
+
+const defaultRiskyKeywords = [
+  "delete",
+  "remove",
+  "destroy",
+  "drop",
+  "truncate",
+  "wipe",
+  "erase",
+  "overwrite",
+];
+
+const approvalToolsEnv = (process.env.AGENT_APPROVAL_TOOLS ?? "").toLowerCase();
+const approvalTools = new Set(
+  approvalToolsEnv
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean)
+);
+
+const approvalKeywordsEnv = (process.env.AGENT_APPROVAL_KEYWORDS ?? "").toLowerCase();
+const approvalKeywords = new Set(
+  approvalKeywordsEnv
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean)
+);
+
+const operationMode = (process.env.AGENT_OPERATION_MODE ?? "guided").toLowerCase();
+const explorationRequiresApproval =
+  (process.env.AGENT_EXPLORATION_AUTO_APPROVE ?? "false").toLowerCase() !== "true";
+
+export type PlanAssessment = {
+  mode: "guided" | "exploratory";
+  requiresApproval: boolean;
+  reasons: string[];
+  plan: Plan;
+};
+
+function detectRiskySignals(content: string): string[] {
+  const normalized = content.toLowerCase();
+  const risks = new Set<string>();
+
+  for (const keyword of defaultRiskyKeywords) {
+    if (normalized.includes(keyword)) risks.add(keyword);
+  }
+
+  for (const keyword of approvalKeywords) {
+    if (normalized.includes(keyword)) risks.add(keyword);
+  }
+
+  return Array.from(risks);
+}
+
+export function assessPlan(userInput: string, plan: Plan): PlanAssessment {
+  const safeInput = Security.validateInput(userInput);
+  const serializedPlan = JSON.stringify(plan.steps).toLowerCase();
+
+  const mode = operationMode === "exploratory" ? "exploratory" : "guided";
+  const reasons: string[] = [];
+
+  if (mode === "exploratory" && explorationRequiresApproval) {
+    reasons.push("Exploratory mode requires approval before executing a new plan.");
+  }
+
+  const riskSignals = detectRiskySignals(`${safeInput}\n${serializedPlan}`);
+  if (riskSignals.length) {
+    reasons.push(`Risky intent detected (${riskSignals.join(", ")}) requiring approval.`);
+  }
+
+  const riskyTool = plan.steps.find((step) => approvalTools.has(step.tool.toLowerCase()));
+  if (riskyTool) {
+    reasons.push(`Tool ${riskyTool.tool} is gated for approval.`);
+  }
+
+  return { mode, requiresApproval: reasons.length > 0, reasons, plan };
+}

--- a/src/OperationMode.ts
+++ b/src/OperationMode.ts
@@ -45,13 +45,14 @@ function detectRiskySignals(content: string): string[] {
   const normalized = content.toLowerCase();
   const risks = new Set<string>();
 
-  for (const keyword of defaultRiskyKeywords) {
-    if (normalized.includes(keyword)) risks.add(keyword);
-  }
+  const addIfPresent = (keyword: string) => {
+    if (normalized.includes(keyword)) {
+      risks.add(keyword);
+    }
+  };
 
-  for (const keyword of approvalKeywords) {
-    if (normalized.includes(keyword)) risks.add(keyword);
-  }
+  defaultRiskyKeywords.forEach(addIfPresent);
+  approvalKeywords.forEach(addIfPresent);
 
   return Array.from(risks);
 }

--- a/src/ResponseGenerator.ts
+++ b/src/ResponseGenerator.ts
@@ -1,20 +1,28 @@
 import { Ollama } from "@langchain/community/llms/ollama";
 import { PromptTemplate } from "@langchain/core/prompts";
 import { Security } from "./security";
+import { parseNumberEnv } from "./utils";
 
 export class ResponseGenerator {
   private model: Ollama;
   private template: PromptTemplate;
 
   constructor() {
+    const persona =
+      process.env.AGENT_PERSONA ??
+      "You are a resilient, creative, and highly effective AI assistant who balances imagination with factual grounding.";
+    const temperature = parseNumberEnv(process.env.AGENT_RESPONSE_TEMPERATURE, 0.7);
+
     this.model = new Ollama({
       baseUrl: "http://localhost:11434",
       model: "llama2",
-      temperature: 0.7,
+      temperature,
     });
 
     this.template = PromptTemplate.fromTemplate(`
-You are an AI assistant. Generate a helpful response based on:
+${persona}
+
+Generate a helpful response based on:
 - User request: {input}
 - Context: {context}
 - Tool results: {results}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,57 +1,54 @@
-import { Agent } from "./Agent";
-import { ToolRegistry } from "./Tools/ToolRegistry";
-import { WebSearchTool } from "./Tools/WebSearchTool";
-import { FileAnalysisTool } from "./Tools/FileAnalysisTool";
-import { CalculatorTool } from "./Tools/CalculatorTool";
-import { PersistentVectorMemory } from "./Memory/PersistentVectorMemory";
-import { Planner } from "./Planner";
-import { ResponseGenerator } from "./ResponseGenerator";
-import { DirectResponseTool } from "./Tools/DirectResponseTool";
 import readline from "readline";
+import { PlanAssessment } from "./OperationMode";
+import { createDefaultAgent } from "./setupAgent";
 
-const toolRegistry = new ToolRegistry();
-toolRegistry.registerTool(new WebSearchTool());
-toolRegistry.registerTool(new FileAnalysisTool());
-toolRegistry.registerTool(new CalculatorTool());
-toolRegistry.registerTool(new DirectResponseTool());
+function promptForApproval(assessment: PlanAssessment, rl: readline.Interface) {
+  console.log(`\n${assessment.mode.toUpperCase()} mode triggered approval:`);
+  console.log(`Reasons: ${assessment.reasons.join("; ")}`);
+  console.log(`Planned steps: ${JSON.stringify(assessment.plan.steps, null, 2)}`);
 
-const memory = new PersistentVectorMemory();
-const planner = new Planner();
-const generator = new ResponseGenerator();
-
-const agent = new Agent(toolRegistry, memory, planner, generator);
+  return new Promise<boolean>((resolve) => {
+    rl.question("Approve plan? (y/N): ", (answer) => {
+      resolve(answer.trim().toLowerCase().startsWith("y"));
+    });
+  });
+}
 
 const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout,
 });
 
+const { agent, memory } = createDefaultAgent((assessment) =>
+  promptForApproval(assessment, rl)
+);
+
 async function main() {
   console.log('Agent initialized. Type your query or "exit" to quit.');
 
   while (true) {
     const input = await new Promise<string>((resolve) =>
-      rl.question('\nUser: ', resolve)
+      rl.question("\nUser: ", resolve)
     );
 
-    if (input.toLowerCase() === 'exit') break;
+    if (input.toLowerCase() === "exit") break;
 
     try {
-      process.stdout.write('Agent: ');
+      process.stdout.write("Agent: ");
       const response = await agent.executeTask(input);
 
       for (const char of response) {
         process.stdout.write(char);
         await new Promise((resolve) => setTimeout(resolve, 20));
       }
-      process.stdout.write('\n');
+      process.stdout.write("\n");
     } catch (error) {
       console.error(`\nError: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
   rl.close();
-  console.log('Session ended');
+  console.log("Session ended");
 }
 
 memory.initialize().then(() => {

--- a/src/setupAgent.ts
+++ b/src/setupAgent.ts
@@ -1,0 +1,26 @@
+import { Agent } from "./Agent";
+import { ToolRegistry } from "./Tools/ToolRegistry";
+import { WebSearchTool } from "./Tools/WebSearchTool";
+import { FileAnalysisTool } from "./Tools/FileAnalysisTool";
+import { CalculatorTool } from "./Tools/CalculatorTool";
+import { PersistentVectorMemory } from "./Memory/PersistentVectorMemory";
+import { Planner } from "./Planner";
+import { ResponseGenerator } from "./ResponseGenerator";
+import { DirectResponseTool } from "./Tools/DirectResponseTool";
+import { PlanAssessment } from "./OperationMode";
+
+export function createDefaultAgent(
+  requestApproval?: (assessment: PlanAssessment) => Promise<boolean>
+): { agent: Agent; memory: PersistentVectorMemory } {
+  const toolRegistry = new ToolRegistry();
+  toolRegistry.registerTool(new WebSearchTool());
+  toolRegistry.registerTool(new FileAnalysisTool());
+  toolRegistry.registerTool(new CalculatorTool());
+  toolRegistry.registerTool(new DirectResponseTool());
+
+  const memory = new PersistentVectorMemory();
+  const planner = new Planner();
+  const generator = new ResponseGenerator();
+
+  return { agent: new Agent(toolRegistry, memory, planner, generator, requestApproval), memory };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,3 +10,8 @@ export function applyTemplate(template: string, values: Record<string, string>):
     Object.prototype.hasOwnProperty.call(values, key) ? values[key] : ""
   );
 }
+
+export function escapeShellArg(value: string): string {
+  const safe = value.replace(/'/g, "'\\''");
+  return `'${safe}'`;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,12 @@
+export function parseNumberEnv(envVar: string | undefined, defaultValue: number): number {
+  if (envVar === undefined || envVar === "") return defaultValue;
+
+  const parsed = Number.parseFloat(envVar);
+  return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+export function applyTemplate(template: string, values: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (_, key) =>
+    Object.prototype.hasOwnProperty.call(values, key) ? values[key] : ""
+  );
+}

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -34,6 +34,13 @@ const rl = readline.createInterface({
   output: process.stdout,
 });
 
+function assertPlaceholder(template: string | undefined, placeholder: string, description: string) {
+  if (!template) return;
+  if (!template.includes(placeholder)) {
+    throw new Error(`${description} must include ${placeholder}`);
+  }
+}
+
 async function runCommand(command: string, description: string) {
   try {
     return await exec(command, { timeout: commandTimeoutMs });
@@ -48,6 +55,7 @@ async function runCommand(command: string, description: string) {
 async function recordAudio(): Promise<string> {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-voice-"));
   const filePath = path.join(tmpDir, "input.wav");
+  assertPlaceholder(recordCommandTemplate, "{file}", "VOICE_RECORD_COMMAND");
   const command = applyTemplate(recordCommandTemplate, { file: filePath });
 
   await runCommand(command, "Recording failed");
@@ -73,6 +81,7 @@ async function transcribeAudio(filePath: string): Promise<string> {
 async function speak(text: string): Promise<void> {
   if (!ttsCommandTemplate) return;
 
+  assertPlaceholder(ttsCommandTemplate, "{text}", "VOICE_TTS_COMMAND");
   const command = applyTemplate(ttsCommandTemplate, { text: escapeShellArg(text) });
   try {
     await runCommand(command, "Speech playback failed");

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -6,7 +6,7 @@ import { exec as execCallback } from "child_process";
 import { promisify } from "util";
 import { PlanAssessment } from "./OperationMode";
 import { createDefaultAgent } from "./setupAgent";
-import { applyTemplate, parseNumberEnv } from "./utils";
+import { applyTemplate, escapeShellArg, parseNumberEnv } from "./utils";
 
 const exec = promisify(execCallback);
 
@@ -38,11 +38,9 @@ async function runCommand(command: string, description: string) {
   try {
     return await exec(command, { timeout: commandTimeoutMs });
   } catch (error) {
-    const stderr = (error as { stderr?: string }).stderr ?? "";
-    const stdout = (error as { stdout?: string }).stdout ?? "";
-    const message = [description, stderr || stdout || (error as Error).message]
-      .filter(Boolean)
-      .join(": ");
+    const execError = error as Error & { stdout?: string; stderr?: string };
+    const output = execError.stderr || execError.stdout || "";
+    const message = [description, output || execError.message].filter(Boolean).join(": ");
     throw new Error(message);
   }
 }
@@ -75,7 +73,7 @@ async function transcribeAudio(filePath: string): Promise<string> {
 async function speak(text: string): Promise<void> {
   if (!ttsCommandTemplate) return;
 
-  const command = applyTemplate(ttsCommandTemplate, { text });
+  const command = applyTemplate(ttsCommandTemplate, { text: escapeShellArg(text) });
   try {
     await runCommand(command, "Speech playback failed");
   } catch (error) {

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -1,0 +1,160 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import readline from "readline";
+import { exec as execCallback } from "child_process";
+import { promisify } from "util";
+import { PlanAssessment } from "./OperationMode";
+import { createDefaultAgent } from "./setupAgent";
+import { applyTemplate, parseNumberEnv } from "./utils";
+
+const exec = promisify(execCallback);
+
+const recordSeconds = parseNumberEnv(process.env.VOICE_RECORD_SECONDS, 6);
+const recordCommandTemplate =
+  process.env.VOICE_RECORD_COMMAND ??
+  `ffmpeg -hide_banner -loglevel error -f alsa -i default -t ${recordSeconds} -ac 1 -ar 16000 {file}`;
+const sttCommandTemplate = process.env.VOICE_STT_COMMAND;
+const ttsCommandTemplate = process.env.VOICE_TTS_COMMAND;
+const commandTimeoutMs = parseNumberEnv(process.env.VOICE_COMMAND_TIMEOUT_MS, 20000);
+
+async function requestApproval(assessment: PlanAssessment): Promise<boolean> {
+  console.log(`\n${assessment.mode.toUpperCase()} mode requires approval.`);
+  console.log(`Reasons: ${assessment.reasons.join("; ")}`);
+  console.log(`Planned steps: ${JSON.stringify(assessment.plan.steps, null, 2)}`);
+
+  const answer = await ask("Approve plan? (y/N): ");
+  return answer.trim().toLowerCase().startsWith("y");
+}
+
+const { agent, memory } = createDefaultAgent(requestApproval);
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+async function runCommand(command: string, description: string) {
+  try {
+    return await exec(command, { timeout: commandTimeoutMs });
+  } catch (error) {
+    const stderr = (error as { stderr?: string }).stderr ?? "";
+    const stdout = (error as { stdout?: string }).stdout ?? "";
+    const message = [description, stderr || stdout || (error as Error).message]
+      .filter(Boolean)
+      .join(": ");
+    throw new Error(message);
+  }
+}
+
+async function recordAudio(): Promise<string> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-voice-"));
+  const filePath = path.join(tmpDir, "input.wav");
+  const command = applyTemplate(recordCommandTemplate, { file: filePath });
+
+  await runCommand(command, "Recording failed");
+  return filePath;
+}
+
+async function transcribeAudio(filePath: string): Promise<string> {
+  if (!sttCommandTemplate) {
+    throw new Error(
+      "Set VOICE_STT_COMMAND to a command that prints the transcription (include {file} placeholder)."
+    );
+  }
+
+  if (!sttCommandTemplate.includes("{file}")) {
+    throw new Error("VOICE_STT_COMMAND must include {file} to point at the WAV recording");
+  }
+
+  const command = applyTemplate(sttCommandTemplate, { file: filePath });
+  const { stdout } = await runCommand(command, "Transcription failed");
+  return stdout.trim();
+}
+
+async function speak(text: string): Promise<void> {
+  if (!ttsCommandTemplate) return;
+
+  const command = applyTemplate(ttsCommandTemplate, { text });
+  try {
+    await runCommand(command, "Speech playback failed");
+  } catch (error) {
+    console.warn((error as Error).message);
+  }
+}
+
+async function captureUtterance(): Promise<string> {
+  const filePath = await recordAudio();
+  try {
+    return await transcribeAudio(filePath);
+  } finally {
+    await fs.rm(path.dirname(filePath), { recursive: true, force: true });
+  }
+}
+
+async function ask(prompt: string): Promise<string> {
+  return new Promise((resolve) => rl.question(prompt, resolve));
+}
+
+async function main() {
+  console.log(
+    'Voice assistant ready. Press Enter to speak, or type text. Type "exit" to quit.'
+  );
+
+  if (!sttCommandTemplate) {
+    console.warn("VOICE_STT_COMMAND is not set; speech capture will fail until configured.");
+  }
+
+  console.log(
+    `Config: record ${recordSeconds}s clips, command timeout ${commandTimeoutMs}ms${
+      ttsCommandTemplate ? "" : "; TTS disabled"
+    }.`
+  );
+
+  while (true) {
+    const userInput = await ask("\nYou (Enter to talk): ");
+
+    if (userInput.toLowerCase() === "exit") break;
+
+    let message = userInput.trim();
+
+    if (!message) {
+      try {
+        message = await captureUtterance();
+      } catch (error) {
+        console.error(
+          `Capture failed: ${error instanceof Error ? error.message : String(error)}. ` +
+            "Type instead to continue."
+        );
+        continue;
+      }
+    }
+
+    if (!message) {
+      console.log("No speech detected; try again.");
+      continue;
+    }
+
+    try {
+      console.log("Agent thinking...");
+      const response = await agent.executeTask(message);
+      console.log(`Agent: ${response}`);
+
+      await speak(response);
+    } catch (error) {
+      console.error(
+        `Agent error: ${error instanceof Error ? error.message : String(error)}. Continuing...`
+      );
+    }
+  }
+
+  rl.close();
+  console.log("Session ended");
+}
+
+memory.initialize().then(() => {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared utility for safe numeric env parsing and template substitution
- apply the helpers to voice loop configuration and response generation defaults
- log full errors when voice mode fails to aid debugging

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69300a1532b48325a5715900969c8d56)